### PR TITLE
M3.2: add metadata & versioning for feature runs

### DIFF
--- a/src/buff/cli.py
+++ b/src/buff/cli.py
@@ -2,36 +2,73 @@
 
 from __future__ import annotations
 
-import sys
+import argparse
 from pathlib import Path
 
 import pandas as pd
 
+from buff.features.metadata import build_metadata, sha256_file, write_json
+from buff.features.registry import FEATURES
 from buff.features.runner import run_features
 
 
-def _read_input(path: Path) -> pd.DataFrame:
-    if not path.exists():
-        raise FileNotFoundError(f"Input not found: {path}")
-    if path.suffix.lower() == ".csv":
-        return pd.read_csv(path)
-    if path.suffix.lower() == ".parquet":
-        return pd.read_parquet(path, engine="pyarrow")
+def _detect_input_format(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix == ".parquet":
+        return "parquet"
     raise ValueError("Input must be .csv or .parquet")
 
 
+def _read_input(path: Path, input_format: str) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Input not found: {path}")
+    if input_format == "csv":
+        return pd.read_csv(path)
+    if input_format == "parquet":
+        return pd.read_parquet(path, engine="pyarrow")
+    raise ValueError("Input format must be csv or parquet")
+
+
 def main() -> None:
-    if len(sys.argv) != 4 or sys.argv[1] != "features":
-        print("Usage: buff features <input_path> <output_path>")
+    parser = argparse.ArgumentParser(prog="buff")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    features_parser = subparsers.add_parser("features", help="Generate features")
+    features_parser.add_argument("input_path")
+    features_parser.add_argument("output_path")
+    features_parser.add_argument("--meta", dest="meta_path")
+
+    args = parser.parse_args()
+    if args.command != "features":
         raise SystemExit(2)
 
-    input_path = Path(sys.argv[2])
-    output_path = Path(sys.argv[3])
+    input_path = Path(args.input_path)
+    output_path = Path(args.output_path)
+    meta_path = Path(args.meta_path) if args.meta_path else Path(f"{output_path}.meta.json")
 
-    df = _read_input(input_path)
+    input_format = _detect_input_format(input_path)
+    input_sha256 = sha256_file(input_path)
+    df = _read_input(input_path, input_format)
+
     out = run_features(df)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_parquet(output_path, engine="pyarrow")
+
+    output_sha256 = sha256_file(output_path)
+    metadata = build_metadata(
+        input_path=str(input_path),
+        input_format=input_format,
+        input_sha256=input_sha256,
+        output_path=str(output_path),
+        output_sha256=output_sha256,
+        row_count=int(out.shape[0]),
+        columns=list(out.columns),
+        features=list(FEATURES.keys()),
+        feature_params={"ema": 20, "rsi": 14, "atr": 14},
+    )
+    write_json(meta_path, metadata)
 
 
 if __name__ == "__main__":

--- a/src/buff/features/metadata.py
+++ b/src/buff/features/metadata.py
@@ -1,0 +1,77 @@
+"""Metadata helpers for deterministic feature runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def sha256_file(path: str | Path) -> str:
+    """Compute sha256 for a file in 1MB chunks."""
+    file_path = Path(path)
+    hasher = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def get_git_sha() -> str | None:
+    """Return current git SHA, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def write_json(path: str | Path, obj: dict[str, Any]) -> None:
+    """Write JSON with stable formatting."""
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as handle:
+        json.dump(obj, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def build_metadata(
+    *,
+    input_path: str,
+    input_format: str,
+    input_sha256: str,
+    output_path: str,
+    output_sha256: str,
+    row_count: int,
+    columns: list[str],
+    features: list[str],
+    feature_params: dict[str, int],
+) -> dict[str, Any]:
+    """Build metadata for a feature run."""
+    return {
+        "schema_version": "1.0",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "git_sha": get_git_sha(),
+        "input_path": input_path,
+        "input_format": input_format,
+        "input_sha256": input_sha256,
+        "output_path": output_path,
+        "output_format": "parquet",
+        "output_sha256": output_sha256,
+        "row_count": row_count,
+        "columns": columns,
+        "features": features,
+        "feature_params": feature_params,
+    }

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -1,0 +1,56 @@
+"""CLI metadata test."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from buff import cli
+
+
+def _is_hex(value: str) -> bool:
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return len(value) == 64
+
+
+def test_cli_metadata(tmp_path: Path) -> None:
+    source = Path("tests/goldens/expected.csv")
+    input_path = tmp_path / "expected.csv"
+    shutil.copyfile(source, input_path)
+
+    output_path = tmp_path / "output.parquet"
+    meta_path = Path(f"{output_path}.meta.json")
+
+    argv = ["buff", "features", str(input_path), str(output_path)]
+    original_argv = sys.argv
+    try:
+        sys.argv = argv
+        cli.main()
+    finally:
+        sys.argv = original_argv
+
+    assert output_path.exists()
+    assert meta_path.exists()
+
+    payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "1.0"
+    assert payload["features"] == ["ema_20", "rsi_14", "atr_14"]
+
+    output_df = pd.read_parquet(output_path, engine="pyarrow")
+    assert payload["row_count"] == int(output_df.shape[0])
+    assert payload["row_count"] > 0
+
+    assert _is_hex(payload["input_sha256"])
+    assert _is_hex(payload["output_sha256"])
+
+    assert payload["columns"] == ["ema_20", "rsi_14", "atr_14"]
+
+    git_sha = payload.get("git_sha")
+    assert git_sha is None or (len(git_sha) == 40 and all(ch in "0123456789abcdef" for ch in git_sha.lower()))


### PR DESCRIPTION
## Summary

Adds reproducible metadata and versioning to feature runs.

Each execution of `buff features` now produces a deterministic metadata file
alongside the output, enabling full auditability and reproducibility.

## What’s included

- Metadata module with:
  - schema version
  - UTC timestamp
  - git commit SHA
  - input/output SHA256 checksums
  - row count and column list
  - feature list and parameters
- CLI extension:
  - `buff features <input> <output> [--meta <path>]`
  - automatic `<output>.meta.json` when `--meta` is omitted
- Tests validating metadata creation and consistency with output

## Why this matters

This ensures every feature artifact can be traced back to:
- the exact input data
- the exact code version
- the exact feature configuration

No new indicators or ML logic are introduced.
