### PR TITLE
M3.3: enforce OHLCV data contracts with validation and tests

### DIFF
--- a/src/buff/data/contracts.py
+++ b/src/buff/data/contracts.py
@@ -1,0 +1,36 @@
+"""Data contracts for OHLCV inputs."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+REQUIRED_COLUMNS = ["timestamp", "open", "high", "low", "close"]
+
+
+def validate_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+    data = df.copy()
+    timestamps = pd.to_datetime(data["timestamp"], errors="coerce", utc=True)
+    if timestamps.isna().any():
+        raise ValueError("Invalid timestamp values")
+    if timestamps.duplicated().any():
+        raise ValueError("Duplicate timestamps are not allowed")
+    if not timestamps.is_monotonic_increasing:
+        raise ValueError("Timestamps must be monotonic increasing")
+    data["timestamp"] = timestamps
+
+    for col in ["open", "high", "low", "close"]:
+        numeric = pd.to_numeric(data[col], errors="coerce")
+        if numeric.isna().any():
+            raise ValueError(f"Non-numeric or NaN values found in '{col}'")
+        data[col] = numeric.astype(float)
+
+    out = data[REQUIRED_COLUMNS].copy()
+    out = out.sort_values("timestamp")
+    out.index = out["timestamp"]
+    out = out.drop(columns=["timestamp"])
+    return out

--- a/src/buff/features/runner.py
+++ b/src/buff/features/runner.py
@@ -4,20 +4,15 @@ from __future__ import annotations
 
 import pandas as pd
 
+from buff.data.contracts import validate_ohlcv
 from buff.features.registry import FEATURES
 
 
-REQUIRED_INPUT_COLUMNS = ["timestamp", "open", "high", "low", "close"]
 OUTPUT_COLUMNS = ["ema_20", "rsi_14", "atr_14"]
 
 
 def run_features(df: pd.DataFrame) -> pd.DataFrame:
-    missing = [col for col in REQUIRED_INPUT_COLUMNS if col not in df.columns]
-    if missing:
-        raise ValueError(f"Missing required columns: {missing}")
-
-    input_df = df.copy()
-    input_df = input_df.sort_values("timestamp").reset_index(drop=True)
+    input_df = validate_ohlcv(df)
 
     features = {}
     for name in OUTPUT_COLUMNS:
@@ -25,6 +20,6 @@ def run_features(df: pd.DataFrame) -> pd.DataFrame:
         features[name] = spec["callable"](input_df)
 
     out = pd.DataFrame(features)
-    out.index = pd.to_datetime(input_df["timestamp"], utc=True)
+    out.index = input_df.index
     out = out[OUTPUT_COLUMNS]
     return out

--- a/tests/test_data_contracts.py
+++ b/tests/test_data_contracts.py
@@ -1,0 +1,43 @@
+"""Tests for OHLCV data contracts."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from buff.data.contracts import validate_ohlcv
+
+
+def test_valid_input_passes() -> None:
+    df = pd.read_csv("tests/goldens/expected.csv")
+    out = validate_ohlcv(df)
+    assert out.index.is_monotonic_increasing
+    assert list(out.columns) == ["open", "high", "low", "close"]
+
+
+def test_missing_column_fails() -> None:
+    df = pd.read_csv("tests/goldens/expected.csv")
+    df = df.drop(columns=["close"])
+    with pytest.raises(ValueError):
+        validate_ohlcv(df)
+
+
+def test_bad_dtype_fails() -> None:
+    df = pd.read_csv("tests/goldens/expected.csv")
+    df.loc[0, "close"] = "bad"
+    with pytest.raises(ValueError):
+        validate_ohlcv(df)
+
+
+def test_duplicate_timestamp_fails() -> None:
+    df = pd.read_csv("tests/goldens/expected.csv")
+    df.loc[1, "timestamp"] = df.loc[0, "timestamp"]
+    with pytest.raises(ValueError):
+        validate_ohlcv(df)
+
+
+def test_non_monotonic_timestamp_fails() -> None:
+    df = pd.read_csv("tests/goldens/expected.csv")
+    df = df.iloc[::-1].reset_index(drop=True)
+    with pytest.raises(ValueError):
+        validate_ohlcv(df)


### PR DESCRIPTION
Adds strict OHLCV data contracts to protect the feature pipeline from invalid inputs.

- Enforces required columns and numeric dtypes
- Validates timestamp parsing, ordering, uniqueness, and UTC policy
- Integrates validation into the feature runner/CLI
- Adds focused boundary tests for invalid inputs

This ensures the pipeline either runs correctly on valid market data
or fails fast with clear errors.
