### PR TITLE
M4.2: dual-mode feature runner with validity metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,45 @@ This will:
 - Verify that `missing_examples` timestamps do NOT exist in data (correctly marked as missing)
 - Print verification results
 
+## Feature Engine (M4.1 / M4.2)
+
+The feature engine produces deterministic, preset-only indicators from validated OHLCV input.
+
+### Presets (Tier-1)
+
+| Preset | Inputs | Outputs | Params |
+| --- | --- | --- | --- |
+| ema_20 | close | ema_20 | period=20 |
+| rsi_14 | close | rsi_14 | period=14 |
+| atr_14 | high, low, close | atr_14 | period=14 |
+| sma_20 | close | sma_20 | period=20 |
+| std_20 | close | std_20 | period=20, ddof=0 |
+| bbands_20_2 | close | bb_mid_20_2, bb_upper_20_2, bb_lower_20_2 | period=20, k=2.0, ddof=0 |
+| macd_12_26_9 | close | macd_12_26_9, macd_signal_12_26_9, macd_hist_12_26_9 | fast=12, slow=26, signal=9 |
+
+### CLI
+
+Generate features from CSV or Parquet:
+
+```bash
+python -m src.buff.cli features <input_path> <output_path> [--meta <meta_path>]
+```
+
+### Train vs Live Modes
+
+The runner supports two modes:
+
+- train (default): identical to the legacy behavior, no trimming.
+- live: no trimming, output length equals input length, warmup NaNs preserved.
+
+Validity metadata is recorded per preset in feature_params using the reserved key
+`_valid_from` (first reliable index). See `docs/features.md`.
+
+### Goldens
+
+Golden outputs live at `tests/goldens/expected.csv` and are preset-only. Tests compare
+indicator outputs and runner output against these goldens. See `docs/goldens.md`.
+
 ## Project Status
 
 🚧 Phase 0–1: Repo bootstrap + data pipeline (in progress)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,45 @@
+# Feature Engine (M4.1 / M4.2)
+
+This document defines the feature engine contract for deterministic indicator computation.
+
+## Registry Structure
+
+Each preset is defined in the registry as a dict with:
+
+- requires: list of required input columns (e.g., ["close"])
+- func: callable that computes the indicator
+- params: parameter dict passed to func
+- outputs: list of output column names for the preset
+
+## Multi-Output Mapping Rules
+
+- If func returns a Series, it is written to outputs[0].
+- If func returns a DataFrame, its columns are renamed to outputs in order.
+- Output column order is deterministic and follows the registry order.
+
+## Warmup and NaN Policy
+
+All presets preserve warmup NaNs. The runner does not trim rows.
+The first reliable index per preset is recorded as valid_from.
+
+## Validity Metadata
+
+Validity is stored without changing the metadata schema:
+
+feature_params[preset]["_valid_from"] = <int index>
+
+valid_from is the first index where the feature becomes reliable. For MACD,
+valid_from is warmup-1.
+
+## Presets
+
+Legacy presets:
+- ema_20 -> outputs: ema_20 (period=20)
+- rsi_14 -> outputs: rsi_14 (period=14)
+- atr_14 -> outputs: atr_14 (period=14)
+
+Tier-1 presets:
+- sma_20 -> outputs: sma_20 (period=20)
+- std_20 -> outputs: std_20 (period=20, ddof=0)
+- bbands_20_2 -> outputs: bb_mid_20_2, bb_upper_20_2, bb_lower_20_2 (period=20, k=2.0, ddof=0)
+- macd_12_26_9 -> outputs: macd_12_26_9, macd_signal_12_26_9, macd_hist_12_26_9 (fast=12, slow=26, signal=9)

--- a/docs/goldens.md
+++ b/docs/goldens.md
@@ -1,0 +1,14 @@
+# Goldens
+
+Golden indicator outputs live at `tests/goldens/expected.csv`.
+
+## Purpose
+
+- Deterministic, preset-only expected values.
+- Used by tests to validate indicator math and runner output.
+
+## Rules
+
+- Do not regenerate goldens unless the preset specification changes.
+- Goldens are limited to the supported presets only.
+- All comparisons use strict tolerances with NaN-aware equality.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -24,3 +24,19 @@ Only the following are shared across modes:
 Rule:
 
 "No shared state, no shared config, no shared outputs."
+
+## Runner Modes (Train vs Live)
+
+The feature runner supports a separate notion of mode:
+
+- train (default): identical to the legacy behavior, no trimming.
+- live: no trimming, output length equals input length, warmup NaNs preserved.
+
+These runner modes are independent of the Manual/System architecture modes above.
+
+Example (expected behavior):
+
+```text
+train: output length == input length, warmup NaNs preserved
+live:  output length == input length, warmup NaNs preserved
+```


### PR DESCRIPTION
Adds train/live modes to the feature runner with validity metadata; docs updated accordingly.
