### PR TITLE
M3: add multi-timeframe market state rules

### DIFF
--- a/knowledge/market_state_rules.yaml
+++ b/knowledge/market_state_rules.yaml
@@ -1,1 +1,1570 @@
-[]
+[
+  {
+    "id": "state.1m.trend.ema30",
+    "name": "TrendState EMA30 (1m)",
+    "category": "market_state",
+    "timeframe": "1m",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1m.momentum.rsi14",
+    "name": "MomentumState RSI14 (1m)",
+    "category": "market_state",
+    "timeframe": "1m",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1m.volatility.atr14",
+    "name": "VolatilityState ATR14 (1m)",
+    "category": "market_state",
+    "timeframe": "1m",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1m.regime.adx14",
+    "name": "RegimeState ADX14 (1m)",
+    "category": "market_state",
+    "timeframe": "1m",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.5m.trend.ema30",
+    "name": "TrendState EMA30 (5m)",
+    "category": "market_state",
+    "timeframe": "5m",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.5m.momentum.rsi14",
+    "name": "MomentumState RSI14 (5m)",
+    "category": "market_state",
+    "timeframe": "5m",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.5m.volatility.atr14",
+    "name": "VolatilityState ATR14 (5m)",
+    "category": "market_state",
+    "timeframe": "5m",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.5m.regime.adx14",
+    "name": "RegimeState ADX14 (5m)",
+    "category": "market_state",
+    "timeframe": "5m",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.15m.trend.ema30",
+    "name": "TrendState EMA30 (15m)",
+    "category": "market_state",
+    "timeframe": "15m",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.15m.momentum.rsi14",
+    "name": "MomentumState RSI14 (15m)",
+    "category": "market_state",
+    "timeframe": "15m",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.15m.volatility.atr14",
+    "name": "VolatilityState ATR14 (15m)",
+    "category": "market_state",
+    "timeframe": "15m",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.15m.regime.adx14",
+    "name": "RegimeState ADX14 (15m)",
+    "category": "market_state",
+    "timeframe": "15m",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.30m.trend.ema30",
+    "name": "TrendState EMA30 (30m)",
+    "category": "market_state",
+    "timeframe": "30m",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.30m.momentum.rsi14",
+    "name": "MomentumState RSI14 (30m)",
+    "category": "market_state",
+    "timeframe": "30m",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.30m.volatility.atr14",
+    "name": "VolatilityState ATR14 (30m)",
+    "category": "market_state",
+    "timeframe": "30m",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.30m.regime.adx14",
+    "name": "RegimeState ADX14 (30m)",
+    "category": "market_state",
+    "timeframe": "30m",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.1h.trend.ema30",
+    "name": "TrendState EMA30 (1h)",
+    "category": "market_state",
+    "timeframe": "1h",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1h.momentum.rsi14",
+    "name": "MomentumState RSI14 (1h)",
+    "category": "market_state",
+    "timeframe": "1h",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1h.volatility.atr14",
+    "name": "VolatilityState ATR14 (1h)",
+    "category": "market_state",
+    "timeframe": "1h",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1h.regime.adx14",
+    "name": "RegimeState ADX14 (1h)",
+    "category": "market_state",
+    "timeframe": "1h",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.2h.trend.ema30",
+    "name": "TrendState EMA30 (2h)",
+    "category": "market_state",
+    "timeframe": "2h",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.2h.momentum.rsi14",
+    "name": "MomentumState RSI14 (2h)",
+    "category": "market_state",
+    "timeframe": "2h",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.2h.volatility.atr14",
+    "name": "VolatilityState ATR14 (2h)",
+    "category": "market_state",
+    "timeframe": "2h",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.2h.regime.adx14",
+    "name": "RegimeState ADX14 (2h)",
+    "category": "market_state",
+    "timeframe": "2h",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.4h.trend.ema30",
+    "name": "TrendState EMA30 (4h)",
+    "category": "market_state",
+    "timeframe": "4h",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.4h.momentum.rsi14",
+    "name": "MomentumState RSI14 (4h)",
+    "category": "market_state",
+    "timeframe": "4h",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.4h.volatility.atr14",
+    "name": "VolatilityState ATR14 (4h)",
+    "category": "market_state",
+    "timeframe": "4h",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.4h.regime.adx14",
+    "name": "RegimeState ADX14 (4h)",
+    "category": "market_state",
+    "timeframe": "4h",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.1d.trend.ema30",
+    "name": "TrendState EMA30 (1d)",
+    "category": "market_state",
+    "timeframe": "1d",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1d.momentum.rsi14",
+    "name": "MomentumState RSI14 (1d)",
+    "category": "market_state",
+    "timeframe": "1d",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1d.volatility.atr14",
+    "name": "VolatilityState ATR14 (1d)",
+    "category": "market_state",
+    "timeframe": "1d",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1d.regime.adx14",
+    "name": "RegimeState ADX14 (1d)",
+    "category": "market_state",
+    "timeframe": "1d",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.1w.trend.ema30",
+    "name": "TrendState EMA30 (1w)",
+    "category": "market_state",
+    "timeframe": "1w",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1w.momentum.rsi14",
+    "name": "MomentumState RSI14 (1w)",
+    "category": "market_state",
+    "timeframe": "1w",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1w.volatility.atr14",
+    "name": "VolatilityState ATR14 (1w)",
+    "category": "market_state",
+    "timeframe": "1w",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1w.regime.adx14",
+    "name": "RegimeState ADX14 (1w)",
+    "category": "market_state",
+    "timeframe": "1w",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.2w.trend.ema30",
+    "name": "TrendState EMA30 (2w)",
+    "category": "market_state",
+    "timeframe": "2w",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.2w.momentum.rsi14",
+    "name": "MomentumState RSI14 (2w)",
+    "category": "market_state",
+    "timeframe": "2w",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.2w.volatility.atr14",
+    "name": "VolatilityState ATR14 (2w)",
+    "category": "market_state",
+    "timeframe": "2w",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.2w.regime.adx14",
+    "name": "RegimeState ADX14 (2w)",
+    "category": "market_state",
+    "timeframe": "2w",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.1M.trend.ema30",
+    "name": "TrendState EMA30 (1M)",
+    "category": "market_state",
+    "timeframe": "1M",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1M.momentum.rsi14",
+    "name": "MomentumState RSI14 (1M)",
+    "category": "market_state",
+    "timeframe": "1M",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1M.volatility.atr14",
+    "name": "VolatilityState ATR14 (1M)",
+    "category": "market_state",
+    "timeframe": "1M",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1M.regime.adx14",
+    "name": "RegimeState ADX14 (1M)",
+    "category": "market_state",
+    "timeframe": "1M",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.3M.trend.ema30",
+    "name": "TrendState EMA30 (3M)",
+    "category": "market_state",
+    "timeframe": "3M",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.3M.momentum.rsi14",
+    "name": "MomentumState RSI14 (3M)",
+    "category": "market_state",
+    "timeframe": "3M",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.3M.volatility.atr14",
+    "name": "VolatilityState ATR14 (3M)",
+    "category": "market_state",
+    "timeframe": "3M",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.3M.regime.adx14",
+    "name": "RegimeState ADX14 (3M)",
+    "category": "market_state",
+    "timeframe": "3M",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.6M.trend.ema30",
+    "name": "TrendState EMA30 (6M)",
+    "category": "market_state",
+    "timeframe": "6M",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.6M.momentum.rsi14",
+    "name": "MomentumState RSI14 (6M)",
+    "category": "market_state",
+    "timeframe": "6M",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.6M.volatility.atr14",
+    "name": "VolatilityState ATR14 (6M)",
+    "category": "market_state",
+    "timeframe": "6M",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.6M.regime.adx14",
+    "name": "RegimeState ADX14 (6M)",
+    "category": "market_state",
+    "timeframe": "6M",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  },
+  {
+    "id": "state.1Y.trend.ema30",
+    "name": "TrendState EMA30 (1Y)",
+    "category": "market_state",
+    "timeframe": "1Y",
+    "description": "Trend state using EMA(30) slope and close position.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "ema_period": 30
+    },
+    "formula": "Compute ema30 on the same timeframe. up if close>ema30 and ema30>ema30_prev; down if close<ema30 and ema30<ema30_prev; else flat.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "up",
+        "down",
+        "flat"
+      ],
+      "default": "flat"
+    },
+    "constraints": "Requires ema30 and ema30_prev on the same timeframe.",
+    "references": [
+      "indicator.ema"
+    ]
+  },
+  {
+    "id": "state.1Y.momentum.rsi14",
+    "name": "MomentumState RSI14 (1Y)",
+    "category": "market_state",
+    "timeframe": "1Y",
+    "description": "Momentum state using RSI(14) thresholds.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "rsi_period": 14
+    },
+    "formula": "Compute rsi14 on the same timeframe. positive if rsi14>=55; negative if rsi14<=45; else neutral.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "positive",
+        "neutral",
+        "negative"
+      ],
+      "default": "neutral"
+    },
+    "constraints": "Requires rsi14 on the same timeframe.",
+    "references": [
+      "indicator.rsi"
+    ]
+  },
+  {
+    "id": "state.1Y.volatility.atr14",
+    "name": "VolatilityState ATR14 (1Y)",
+    "category": "market_state",
+    "timeframe": "1Y",
+    "description": "Volatility state using ATR(14) percent of close and rolling percentiles.",
+    "inputs": [
+      "close"
+    ],
+    "parameters": {
+      "atr_period": 14,
+      "window": 200
+    },
+    "formula": "Compute atr14 and atr_pct=atr14/close on the same timeframe. high if atr_pct>=p80(atr_pct, window=200). low if atr_pct<=p20(atr_pct, window=200). else normal. If insufficient data, close==0, or NaN, set undefined.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "undefined"
+      ],
+      "default": "undefined"
+    },
+    "constraints": "Requires atr14, close>0, and at least 200 atr_pct values for percentiles; otherwise undefined.",
+    "references": [
+      "indicator.atr"
+    ]
+  },
+  {
+    "id": "state.1Y.regime.adx14",
+    "name": "RegimeState ADX14 (1Y)",
+    "category": "market_state",
+    "timeframe": "1Y",
+    "description": "Regime state using ADX(14) thresholds.",
+    "inputs": [
+      "high",
+      "low",
+      "close"
+    ],
+    "parameters": {
+      "adx_period": 14
+    },
+    "formula": "Compute adx14 on the same timeframe. trending if adx14>=25; ranging if adx14<=20; else transition.",
+    "output": {
+      "type": "enum",
+      "values": [
+        "trending",
+        "ranging",
+        "transition"
+      ],
+      "default": "transition"
+    },
+    "constraints": "Requires adx14 on the same timeframe.",
+    "references": [
+      "indicator.adx"
+    ]
+  }
+]

--- a/tests/test_market_state_rules.py
+++ b/tests/test_market_state_rules.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+RULES_PATH = Path("knowledge/market_state_rules.yaml")
+
+TIMEFRAMES = [
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "4h",
+    "1d",
+    "1w",
+    "2w",
+    "1M",
+    "3M",
+    "6M",
+    "1Y",
+]
+
+FORBIDDEN_WORDS = [
+    "buy",
+    "sell",
+    "long",
+    "short",
+    "bullish",
+    "bearish",
+    "predict",
+    "prediction",
+    "forecast",
+]
+
+ALLOWED_INPUTS = {"open", "high", "low", "close", "volume"}
+
+ALLOWED_OUTPUTS = {
+    "trend": {"up", "down", "flat"},
+    "momentum": {"positive", "neutral", "negative"},
+    "volatility": {"low", "normal", "high", "undefined"},
+    "regime": {"trending", "ranging", "transition"},
+}
+
+REQUIRED_FIELDS = {
+    "id",
+    "name",
+    "category",
+    "timeframe",
+    "description",
+    "inputs",
+    "parameters",
+    "formula",
+    "output",
+    "constraints",
+    "references",
+}
+
+
+def _load_rules() -> list[dict]:
+    text = RULES_PATH.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import yaml  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise AssertionError("PyYAML required to load rules") from exc
+        payload = yaml.safe_load(text)
+
+    if isinstance(payload, dict) and "rules" in payload:
+        payload = payload["rules"]
+
+    assert isinstance(payload, list), "rules must be a list"
+    return payload
+
+
+def _rule_kind(rule_id: str) -> str:
+    if ".trend." in rule_id:
+        return "trend"
+    if ".momentum." in rule_id:
+        return "momentum"
+    if ".volatility." in rule_id:
+        return "volatility"
+    if ".regime." in rule_id:
+        return "regime"
+    raise AssertionError(f"Unrecognized rule_id kind: {rule_id}")
+
+
+def _text_contains_forbidden(text: str) -> bool:
+    lowered = text.lower()
+    return any(word in lowered for word in FORBIDDEN_WORDS)
+
+
+def test_rules_load_and_count() -> None:
+    rules = _load_rules()
+    assert rules, "rules must not be empty"
+    assert len(rules) == 56
+
+
+def test_rules_have_required_fields() -> None:
+    rules = _load_rules()
+    for rule in rules:
+        assert isinstance(rule, dict)
+        missing = REQUIRED_FIELDS - set(rule.keys())
+        assert not missing, f"missing fields: {missing}"
+
+
+def test_rule_ids_unique() -> None:
+    rules = _load_rules()
+    rule_ids = [rule["id"] for rule in rules]
+    assert len(rule_ids) == len(set(rule_ids))
+
+
+def test_timeframe_coverage() -> None:
+    rules = _load_rules()
+    by_tf: dict[str, list[str]] = {tf: [] for tf in TIMEFRAMES}
+    for rule in rules:
+        tf = rule["timeframe"]
+        assert tf in by_tf
+        by_tf[tf].append(_rule_kind(rule["id"]))
+
+    for tf, kinds in by_tf.items():
+        assert sorted(kinds) == ["momentum", "regime", "trend", "volatility"], tf
+
+
+def test_forbidden_words_absent() -> None:
+    rules = _load_rules()
+    for rule in rules:
+        text_fields = [
+            rule.get("name", ""),
+            rule.get("description", ""),
+            rule.get("formula", ""),
+            rule.get("constraints", ""),
+        ]
+        combined = " ".join(text_fields)
+        assert not _text_contains_forbidden(combined)
+
+
+def test_inputs_and_references_contract() -> None:
+    rules = _load_rules()
+    for rule in rules:
+        inputs = rule["inputs"]
+        assert isinstance(inputs, list)
+        assert inputs, "inputs must not be empty"
+        for value in inputs:
+            assert isinstance(value, str)
+            assert value in ALLOWED_INPUTS
+
+        references = rule["references"]
+        assert isinstance(references, list)
+        assert references, "references must not be empty"
+
+
+def test_output_enums() -> None:
+    rules = _load_rules()
+    for rule in rules:
+        kind = _rule_kind(rule["id"])
+        output = rule["output"]
+        assert isinstance(output, dict)
+        assert output.get("type") == "enum"
+        values = output.get("values")
+        assert isinstance(values, list)
+        assert set(values) == ALLOWED_OUTPUTS[kind]


### PR DESCRIPTION
Adds standardized market state rules for all configured timeframes

Converts indicator outputs into trend/momentum/volatility/regime states

Includes contract-based validation