### PR TITLE
M5: Strategy menu with 3 engines, 10 profiles, deterministic selector & explainability

### DIFF
--- a/src/selector/selector.py
+++ b/src/selector/selector.py
@@ -1,9 +1,60 @@
 from __future__ import annotations
 
-from strategies.registry import StrategyRegistry
+from strategies.registry import build_engines, get_profiles
 
 
-def select_strategy(strategy_id: str, registry: StrategyRegistry) -> str:
-    if not registry.is_registered(strategy_id):
-        raise ValueError("strategy_not_registered")
-    return strategy_id
+def select_strategy(*, market_state: dict, risk_state: str, timeframe: str) -> dict:
+    risk_state_norm = risk_state.upper()
+    reasons: list[str] = []
+
+    if risk_state_norm == "RED":
+        return {
+            "strategy_id": "NONE",
+            "engine_id": None,
+            "risk_state": risk_state_norm,
+            "timeframe": timeframe,
+            "reason": ["RISK_VETO:RED"],
+        }
+
+    engines = build_engines()
+    profiles = get_profiles()
+
+    if risk_state_norm == "YELLOW":
+        profiles = [profile for profile in profiles if profile.conservative]
+        reasons.append("RISK_LIMIT:YELLOW")
+
+    selected = None
+    for profile in profiles:
+        ok_profile, profile_reasons = profile.is_profile_applicable(market_state=market_state)
+        if not ok_profile:
+            continue
+
+        engine = engines.get(profile.engine_id)
+        if engine is None:
+            continue
+
+        ok_engine, engine_reasons = engine.is_applicable(
+            market_state=market_state, timeframe=timeframe
+        )
+        if not ok_engine:
+            continue
+
+        selected = {
+            "strategy_id": profile.strategy_id,
+            "engine_id": profile.engine_id,
+            "risk_state": risk_state_norm,
+            "timeframe": timeframe,
+            "reason": reasons + profile_reasons + engine_reasons + [f"SELECTED:{profile.strategy_id}"],
+        }
+        break
+
+    if selected is None:
+        return {
+            "strategy_id": "NONE",
+            "engine_id": None,
+            "risk_state": risk_state_norm,
+            "timeframe": timeframe,
+            "reason": reasons + ["NO_APPLICABLE_STRATEGY"],
+        }
+
+    return selected

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,5 +1,22 @@
 """Strategy registry and interfaces."""
 
-from .registry import StrategyRegistry, StrategySpec
+from strategies.base import StrategyEngine, StrategyProfile
+from strategies.registry import (
+    StrategyRegistry,
+    StrategySpec,
+    build_engines,
+    build_profiles,
+    get_profile,
+    get_profiles,
+)
 
-__all__ = ["StrategyRegistry", "StrategySpec"]
+__all__ = [
+    "StrategyEngine",
+    "StrategyProfile",
+    "StrategyRegistry",
+    "StrategySpec",
+    "build_engines",
+    "build_profiles",
+    "get_profile",
+    "get_profiles",
+]

--- a/src/strategies/base.py
+++ b/src/strategies/base.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class StrategyEngine(Protocol):
+    engine_id: str
+    description: str
+    required_market_keys: set[str]
+
+    def is_applicable(self, *, market_state: dict, timeframe: str) -> tuple[bool, list[str]]:
+        ...
+
+
+@dataclass(frozen=True)
+class StrategyProfile:
+    strategy_id: str
+    engine_id: str
+    description: str
+    conservative: bool
+    priority: int
+    required_market_keys: set[str]
+    required_conditions: dict[str, object]
+
+    def is_profile_applicable(self, *, market_state: dict) -> tuple[bool, list[str]]:
+        missing = sorted(self.required_market_keys - set(market_state.keys()))
+        if missing:
+            return False, [f"PROFILE_MISSING_KEYS:{','.join(missing)}"]
+
+        for key, expected in self.required_conditions.items():
+            if market_state.get(key) != expected:
+                return False, [f"PROFILE_CONDITION_MISMATCH:{key}"]
+
+        return True, ["PROFILE_OK"]

--- a/src/strategies/engines/__init__.py
+++ b/src/strategies/engines/__init__.py
@@ -1,0 +1,7 @@
+"""Strategy engines for applicability checks."""
+
+from .breakout import BreakoutEngine
+from .mean_revert import MeanRevertEngine
+from .trend import TrendEngine
+
+__all__ = ["BreakoutEngine", "MeanRevertEngine", "TrendEngine"]

--- a/src/strategies/engines/breakout.py
+++ b/src/strategies/engines/breakout.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from strategies.base import StrategyEngine
+
+
+@dataclass(frozen=True)
+class BreakoutEngine(StrategyEngine):
+    engine_id: str = "breakout"
+    description: str = "Breakout applicability checks"
+    required_market_keys: set[str] = field(default_factory=lambda: {"volatility_regime"})
+
+    def is_applicable(self, *, market_state: dict, timeframe: str) -> tuple[bool, list[str]]:
+        missing = sorted(self.required_market_keys - set(market_state.keys()))
+        if missing:
+            return False, [f"ENGINE_MISSING_KEYS:{','.join(missing)}"]
+
+        volatility_regime = market_state.get("volatility_regime")
+        momentum_state = market_state.get("momentum_state")
+        if volatility_regime in {"HIGH", "EXPANDING"} or momentum_state == "SPIKE":
+            return True, ["ENGINE_BREAKOUT_OK"]
+        return False, ["ENGINE_BREAKOUT_NOT_APPLICABLE"]

--- a/src/strategies/engines/mean_revert.py
+++ b/src/strategies/engines/mean_revert.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from strategies.base import StrategyEngine
+
+
+@dataclass(frozen=True)
+class MeanRevertEngine(StrategyEngine):
+    engine_id: str = "mean_revert"
+    description: str = "Mean reversion applicability checks"
+    required_market_keys: set[str] = field(default_factory=lambda: {"trend_state"})
+
+    def is_applicable(self, *, market_state: dict, timeframe: str) -> tuple[bool, list[str]]:
+        missing = sorted(self.required_market_keys - set(market_state.keys()))
+        if missing:
+            return False, [f"ENGINE_MISSING_KEYS:{','.join(missing)}"]
+
+        trend_state = market_state.get("trend_state")
+        if trend_state == "RANGE":
+            return True, ["ENGINE_MEAN_REVERT_OK"]
+        return False, ["ENGINE_MEAN_REVERT_NOT_APPLICABLE"]

--- a/src/strategies/engines/trend.py
+++ b/src/strategies/engines/trend.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from strategies.base import StrategyEngine
+
+
+@dataclass(frozen=True)
+class TrendEngine(StrategyEngine):
+    engine_id: str = "trend"
+    description: str = "Trend applicability checks"
+    required_market_keys: set[str] = field(default_factory=lambda: {"trend_state"})
+
+    def is_applicable(self, *, market_state: dict, timeframe: str) -> tuple[bool, list[str]]:
+        missing = sorted(self.required_market_keys - set(market_state.keys()))
+        if missing:
+            return False, [f"ENGINE_MISSING_KEYS:{','.join(missing)}"]
+
+        trend_state = market_state.get("trend_state")
+        if trend_state in {"UP", "DOWN"}:
+            return True, ["ENGINE_TREND_OK"]
+        return False, ["ENGINE_TREND_NOT_APPLICABLE"]

--- a/tests/test_m5_selector_profiles.py
+++ b/tests/test_m5_selector_profiles.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from selector.selector import select_strategy
+
+
+def test_red_veto() -> None:
+    result = select_strategy(market_state={"trend_state": "UP"}, risk_state="RED", timeframe="1h")
+    assert result["strategy_id"] == "NONE"
+    assert "RISK_VETO:RED" in result["reason"]
+
+
+def test_green_select_trend_conservative_up() -> None:
+    result = select_strategy(market_state={"trend_state": "UP"}, risk_state="GREEN", timeframe="1h")
+    assert result["strategy_id"] == "trend_follow_v1_conservative"
+    assert any(reason.startswith("SELECTED:") for reason in result["reason"])
+
+
+def test_yellow_only_conservative() -> None:
+    result = select_strategy(market_state={"trend_state": "DOWN"}, risk_state="YELLOW", timeframe="1h")
+    assert result["strategy_id"] == "NONE"
+    assert "RISK_LIMIT:YELLOW" in result["reason"]
+
+
+def test_missing_keys_returns_none() -> None:
+    result = select_strategy(market_state={}, risk_state="GREEN", timeframe="1h")
+    assert result["strategy_id"] == "NONE"
+    assert "NO_APPLICABLE_STRATEGY" in result["reason"]
+
+
+def test_deterministic_repeatability() -> None:
+    market_state = {"trend_state": "RANGE", "volatility_regime": "LOW"}
+    result_a = select_strategy(market_state=market_state, risk_state="GREEN", timeframe="1h")
+    result_b = select_strategy(market_state=market_state, risk_state="GREEN", timeframe="1h")
+    assert result_a == result_b


### PR DESCRIPTION
…explainability## Summary

This PR implements **Milestone M5**: a menu-based, deterministic strategy selector.

Scope is intentionally limited to **strategy_id selection only**.

## What is included
- 3 strategy engines: `trend`, `mean_revert`, `breakout`
- 10 fixed strategy profiles mapped to those engines
- Deterministic selector (sorted by priority, then strategy_id)
- Full risk veto:
  - `RED` → `NONE`
  - `YELLOW` → conservative profiles only
- Explainable decisions (structured reason list)
- Conservative behavior on incomplete `market_state`
- Full test coverage for determinism, veto, and missing keys

## What is explicitly NOT included
- ❌ No buy/sell signals
- ❌ No price prediction
- ❌ No execution logic
- ❌ No optimization or parameter tuning

## Purpose
This PR establishes the **decision spine** required for Phase 1(B):
long-running paper trading, audit logging, and deterministic replay.

## Quality
- `ruff check .` → PASS
- `pytest -q` → PASS
