### PR TITLE
B1: Decision records JSONL schema + writer (deterministic hash)

### DIFF
--- a/src/audit/__init__.py
+++ b/src/audit/__init__.py
@@ -1,0 +1,17 @@
+"""Audit helpers for decision records."""
+
+from .decision_records import (
+    DecisionRecordV1,
+    DecisionRecordWriter,
+    canonical_json,
+    ensure_run_dir,
+    sha256_hex,
+)
+
+__all__ = [
+    "DecisionRecordV1",
+    "DecisionRecordWriter",
+    "canonical_json",
+    "ensure_run_dir",
+    "sha256_hex",
+]

--- a/src/audit/decision_records.py
+++ b/src/audit/decision_records.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+
+
+def canonical_json(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(text: str) -> str:
+    digest = sha256(text.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+@dataclass(frozen=True)
+class DecisionRecordV1:
+    schema_version: str
+    run_id: str
+    seq: int
+    ts_utc: str
+    timeframe: str
+    risk_state: str
+    market_state: dict
+    market_state_hash: str
+    selection: dict
+
+    def to_json_line(self) -> str:
+        return canonical_json(asdict(self)) + "\n"
+
+
+def ensure_run_dir(run_id: str) -> str:
+    path = Path("runs") / run_id
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path / "decision_records.jsonl")
+
+
+def _utc_timestamp() -> str:
+    ts = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+    if ts.endswith("+00:00"):
+        return ts.replace("+00:00", "Z")
+    return ts
+
+
+class DecisionRecordWriter:
+    def __init__(self, *, out_path: str, run_id: str) -> None:
+        self._file = open(out_path, "a", encoding="utf-8")
+        self._run_id = run_id
+        self._seq = 0
+
+    def append(
+        self,
+        *,
+        timeframe: str,
+        risk_state: str,
+        market_state: dict,
+        selection: dict,
+    ) -> DecisionRecordV1:
+        market_state_hash = sha256_hex(canonical_json(market_state))
+        record = DecisionRecordV1(
+            schema_version="dr.v1",
+            run_id=self._run_id,
+            seq=self._seq,
+            ts_utc=_utc_timestamp(),
+            timeframe=timeframe,
+            risk_state=risk_state,
+            market_state=market_state,
+            market_state_hash=market_state_hash,
+            selection=selection,
+        )
+        self._file.write(record.to_json_line())
+        self._file.flush()
+        os.fsync(self._file.fileno())
+        self._seq += 1
+        return record
+
+    def close(self) -> None:
+        self._file.close()

--- a/tests/test_decision_records_b1.py
+++ b/tests/test_decision_records_b1.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from audit.decision_records import DecisionRecordWriter, canonical_json, ensure_run_dir, sha256_hex
+from selector.selector import select_strategy
+
+
+def test_canonical_json_deterministic() -> None:
+    d1 = {"b": 1, "a": 2}
+    d2 = {"a": 2, "b": 1}
+    assert canonical_json(d1) == canonical_json(d2)
+
+
+def test_market_state_hash_deterministic() -> None:
+    d1 = {"b": 1, "a": 2}
+    d2 = {"a": 2, "b": 1}
+    assert sha256_hex(canonical_json(d1)) == sha256_hex(canonical_json(d2))
+
+
+def test_writer_appends_jsonl(tmp_path: Path) -> None:
+    out_path = tmp_path / "decision_records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(out_path), run_id="test_run")
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.close()
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    records = [json.loads(line) for line in lines]
+    assert [record["seq"] for record in records] == [0, 1]
+    assert all(record["run_id"] == "test_run" for record in records)
+    assert all(record["schema_version"] == "dr.v1" for record in records)
+    assert all(record["market_state_hash"].startswith("sha256:") for record in records)
+
+
+def test_selector_logs_when_writer_provided(tmp_path: Path) -> None:
+    out_path = Path(ensure_run_dir("test_run"))
+    out_path = tmp_path / out_path.name
+    writer = DecisionRecordWriter(out_path=str(out_path), run_id="test_run")
+    result = select_strategy(
+        market_state={"trend_state": "UP"},
+        risk_state="GREEN",
+        timeframe="1m",
+        record_writer=writer,
+    )
+    writer.close()
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["selection"]["strategy_id"] == result["strategy_id"]


### PR DESCRIPTION
## Summary
Implements Phase 1(B) Step B1: decision records logging in JSONL format with deterministic hashing.

## What’s included
- `DecisionRecordWriter` writing `decision_records.jsonl` (append + flush)
- Fixed schema `dr.v1` with `market_state_hash` (canonical JSON + sha256)
- Optional selector hook: logs a record when a writer is provided
- Tests covering determinism, JSONL appends, and selector integration

## Not included
- No signals, no execution, no prediction, no optimization
- No paper runner and no replay runner (later steps)

## Verification
- `ruff check .` PASS
- `pytest -q` PASS
