### PR TITLE
B2: Replay runner for decision_records (determinism verification)

### DIFF
--- a/src/audit/cli_replay.py
+++ b/src/audit/cli_replay.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+
+from audit.replay import replay_verify
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay decision_records.jsonl and verify determinism.")
+    parser.add_argument("--records", required=True, help="Path to decision_records.jsonl")
+    args = parser.parse_args()
+
+    result = replay_verify(records_path=args.records)
+
+    print(f"TOTAL: {result.total}")
+    print(f"MATCHED: {result.matched}")
+    print(f"MISMATCHED: {result.mismatched}")
+    print(f"HASH_MISMATCH: {result.hash_mismatch}")
+    print(f"ERRORS: {result.errors}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/audit/decision_records.py
+++ b/src/audit/decision_records.py
@@ -17,6 +17,14 @@ def sha256_hex(text: str) -> str:
     return f"sha256:{digest}"
 
 
+def parse_json_line(line: str) -> dict:
+    return json.loads(line)
+
+
+def compute_market_state_hash(market_state: dict) -> str:
+    return sha256_hex(canonical_json(market_state))
+
+
 @dataclass(frozen=True)
 class DecisionRecordV1:
     schema_version: str
@@ -60,7 +68,7 @@ class DecisionRecordWriter:
         market_state: dict,
         selection: dict,
     ) -> DecisionRecordV1:
-        market_state_hash = sha256_hex(canonical_json(market_state))
+        market_state_hash = compute_market_state_hash(market_state)
         record = DecisionRecordV1(
             schema_version="dr.v1",
             run_id=self._run_id,

--- a/src/audit/replay.py
+++ b/src/audit/replay.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from audit.decision_records import compute_market_state_hash, parse_json_line
+from selector.selector import select_strategy
+
+_LAST_LOAD_ERRORS = 0
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    total: int
+    matched: int
+    mismatched: int
+    hash_mismatch: int
+    errors: int
+
+
+def load_decision_records(path: str) -> list[dict]:
+    records: list[dict] = []
+    errors = 0
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = parse_json_line(line)
+            if record.get("schema_version") != "dr.v1":
+                raise ValueError("schema_version")
+            required = {
+                "run_id",
+                "seq",
+                "timeframe",
+                "risk_state",
+                "market_state",
+                "market_state_hash",
+                "selection",
+            }
+            if not required.issubset(record.keys()):
+                raise ValueError("missing_required_fields")
+            records.append(record)
+        except Exception:
+            errors += 1
+    global _LAST_LOAD_ERRORS
+    _LAST_LOAD_ERRORS = errors
+    return records
+
+
+def normalize_selection(sel: dict) -> dict:
+    return {
+        "strategy_id": sel.get("strategy_id"),
+        "engine_id": sel.get("engine_id"),
+        "reason": sel.get("reason", []),
+    }
+
+
+def replay_verify(*, records_path: str) -> ReplayResult:
+    records = load_decision_records(records_path)
+    errors = _LAST_LOAD_ERRORS
+
+    total = len(records)
+    matched = 0
+    mismatched = 0
+    hash_mismatch = 0
+    details: list[dict] = []
+
+    for record in records:
+        expected_hash = record.get("market_state_hash")
+        computed_hash = compute_market_state_hash(record.get("market_state", {}))
+        if computed_hash != expected_hash:
+            hash_mismatch += 1
+            continue
+
+        out = select_strategy(
+            market_state=record.get("market_state", {}),
+            risk_state=record.get("risk_state", ""),
+            timeframe=record.get("timeframe", ""),
+            record_writer=None,
+        )
+        expected = normalize_selection(record.get("selection", {}))
+        got = normalize_selection(out)
+        if expected == got:
+            matched += 1
+        else:
+            mismatched += 1
+            if len(details) < 20:
+                details.append(
+                    {
+                        "seq": record.get("seq"),
+                        "expected": expected,
+                        "got": got,
+                    }
+                )
+
+    if details:
+        print(json.dumps({"mismatches": details}, indent=2))
+
+    return ReplayResult(
+        total=total,
+        matched=matched,
+        mismatched=mismatched,
+        hash_mismatch=hash_mismatch,
+        errors=errors,
+    )

--- a/tests/test_replay_b2.py
+++ b/tests/test_replay_b2.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from audit.decision_records import DecisionRecordWriter
+from audit.replay import replay_verify
+from selector.selector import select_strategy
+
+
+def test_replay_all_matched(tmp_path: Path) -> None:
+    out_path = tmp_path / "decision_records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(out_path), run_id="test_run")
+    select_strategy(
+        market_state={"trend_state": "UP"},
+        risk_state="GREEN",
+        timeframe="1m",
+        record_writer=writer,
+    )
+    select_strategy(
+        market_state={"trend_state": "RANGE", "volatility_regime": "LOW"},
+        risk_state="GREEN",
+        timeframe="1m",
+        record_writer=writer,
+    )
+    writer.close()
+
+    result = replay_verify(records_path=str(out_path))
+    assert result.total == 2
+    assert result.mismatched == 0
+    assert result.hash_mismatch == 0
+    assert result.errors == 0
+
+
+def test_replay_detects_hash_mismatch(tmp_path: Path) -> None:
+    out_path = tmp_path / "decision_records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(out_path), run_id="test_run")
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.close()
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    loaded = json.loads(lines[0])
+    loaded["market_state_hash"] = "sha256:deadbeef"
+    out_path.write_text(json.dumps(loaded) + "\n", encoding="utf-8")
+
+    result = replay_verify(records_path=str(out_path))
+    assert result.hash_mismatch == 1
+    assert result.matched == 0
+
+
+def test_replay_detects_selection_mismatch(tmp_path: Path) -> None:
+    out_path = tmp_path / "decision_records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(out_path), run_id="test_run")
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.close()
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    loaded = json.loads(lines[0])
+    loaded["selection"]["strategy_id"] = "NONE"
+    out_path.write_text(json.dumps(loaded) + "\n", encoding="utf-8")
+
+    result = replay_verify(records_path=str(out_path))
+    assert result.mismatched == 1


### PR DESCRIPTION
## Summary
Adds Phase 1(B) Step B2: a replay runner that verifies selector determinism against recorded decision_records.jsonl.

## What’s included
- JSONL record loader + minimal validation
- Hash verification for market_state (canonical JSON + sha256)
- Replay verifier that re-runs `select_strategy` and compares selection outputs
- CLI entrypoint for local/CI usage
- Tests covering match, hash mismatch, and selection mismatch detection

## Not included
- No paper trading runner
- No live execution
- No UI

## Verification
- `ruff check .` PASS
- `pytest -q` PASS
