### PR TITLE
B3: Fault injection for decision_records/replay (corruption + restart)

### DIFF
--- a/src/audit/faults.py
+++ b/src/audit/faults.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from audit.decision_records import canonical_json
+
+
+def write_corrupted_jsonl(path: str) -> None:
+    record_a = {
+        "schema_version": "dr.v1",
+        "run_id": "test_run",
+        "seq": 0,
+        "ts_utc": "2026-01-01T00:00:00.000Z",
+        "timeframe": "1m",
+        "risk_state": "GREEN",
+        "market_state": {"trend_state": "UP"},
+        "market_state_hash": "sha256:dummy",
+        "selection": {"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    }
+    record_b = {
+        "schema_version": "dr.v1",
+        "run_id": "test_run",
+        "seq": 1,
+        "ts_utc": "2026-01-01T00:00:01.000Z",
+        "timeframe": "1m",
+        "risk_state": "GREEN",
+        "market_state": {"trend_state": "DOWN"},
+        "market_state_hash": "sha256:dummy",
+        "selection": {"strategy_id": "trend_follow_v1_short", "engine_id": "trend", "reason": []},
+    }
+    lines = [
+        canonical_json(record_a),
+        "{bad json",
+        canonical_json(record_b),
+        "{\"schema_version\": \"dr.v1\"",
+    ]
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def truncate_file_mid_line(path: str) -> None:
+    file_path = Path(path)
+    data = file_path.read_bytes()
+    if len(data) < 5:
+        return
+    file_path.write_bytes(data[:-5])
+
+
+def append_valid_record_line(path: str, record: dict) -> None:
+    file_path = Path(path)
+    with file_path.open("a", encoding="utf-8") as handle:
+        handle.write(canonical_json(record))
+        handle.write("\n")

--- a/src/audit/replay.py
+++ b/src/audit/replay.py
@@ -48,6 +48,10 @@ def load_decision_records(path: str) -> list[dict]:
     return records
 
 
+def last_load_errors() -> int:
+    return _LAST_LOAD_ERRORS
+
+
 def normalize_selection(sel: dict) -> dict:
     return {
         "strategy_id": sel.get("strategy_id"),
@@ -56,9 +60,10 @@ def normalize_selection(sel: dict) -> dict:
     }
 
 
-def replay_verify(*, records_path: str) -> ReplayResult:
+def replay_verify(*, records_path: str, strict: bool = False) -> ReplayResult:
+    _ = strict
     records = load_decision_records(records_path)
-    errors = _LAST_LOAD_ERRORS
+    errors = last_load_errors()
 
     total = len(records)
     matched = 0

--- a/tests/test_fault_injection_b3.py
+++ b/tests/test_fault_injection_b3.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from audit.decision_records import DecisionRecordWriter, infer_next_seq_from_jsonl
+from audit.faults import truncate_file_mid_line, write_corrupted_jsonl
+from audit.replay import load_decision_records, replay_verify, last_load_errors
+from selector.selector import select_strategy
+
+
+def test_load_decision_records_tolerates_corruption(tmp_path: Path) -> None:
+    path = tmp_path / "corrupt.jsonl"
+    write_corrupted_jsonl(str(path))
+
+    records = load_decision_records(str(path))
+    assert len(records) >= 2
+    assert last_load_errors() >= 2
+
+
+def test_replay_verify_skips_corrupted_lines(tmp_path: Path) -> None:
+    path = tmp_path / "corrupt.jsonl"
+    write_corrupted_jsonl(str(path))
+
+    result = replay_verify(records_path=str(path))
+    assert result.total >= 2
+    assert result.errors >= 1
+
+
+def test_infer_next_seq_restart_safe(tmp_path: Path) -> None:
+    path = tmp_path / "records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(path), run_id="test_run")
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "DOWN"},
+        selection={"strategy_id": "trend_follow_v1_short", "engine_id": "trend", "reason": []},
+    )
+    writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.close()
+
+    truncate_file_mid_line(str(path))
+    next_seq = infer_next_seq_from_jsonl(str(path))
+    assert next_seq == 2
+
+    writer = DecisionRecordWriter(out_path=str(path), run_id="test_run", start_seq=next_seq)
+    record = writer.append(
+        timeframe="1m",
+        risk_state="GREEN",
+        market_state={"trend_state": "UP"},
+        selection={"strategy_id": "trend_follow_v1_conservative", "engine_id": "trend", "reason": []},
+    )
+    writer.close()
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    loaded = None
+    for line in reversed(lines):
+        try:
+            loaded = json.loads(line)
+            break
+        except json.JSONDecodeError:
+            continue
+    assert loaded is not None
+    assert loaded["seq"] == next_seq
+    assert record.seq == next_seq
+
+
+def test_selector_handles_missing_market_state_keys(tmp_path: Path) -> None:
+    path = tmp_path / "records.jsonl"
+    writer = DecisionRecordWriter(out_path=str(path), run_id="test_run")
+    result = select_strategy(
+        market_state={},
+        risk_state="GREEN",
+        timeframe="1m",
+        record_writer=writer,
+    )
+    writer.close()
+
+    assert result["strategy_id"] == "NONE"
+    replay_result = replay_verify(records_path=str(path))
+    assert replay_result.mismatched == 0


### PR DESCRIPTION
## Summary
Adds Phase 1(B) Step B3: fault injection and restart/corruption robustness for decision_records JSONL and replay verification.

## What’s included
- Fault utilities to generate corrupted/truncated JSONL inputs
- Restart-safe helper to infer next seq from partially corrupted JSONL
- Tests ensuring loaders and replay do not crash on corruption
- Tests covering restart scenarios and missing market_state keys

## Not included
- No paper trading runner
- No live execution
- No UI

## Verification
- `ruff check .` PASS
- `pytest -q` PASS
