### PR TITLE
B4: Paper runner smoke (decision_records + restart + replay verification)

### DIFF
--- a/src/paper/__init__.py
+++ b/src/paper/__init__.py
@@ -1,0 +1,5 @@
+"""Paper runner for smoke testing decision pipeline."""
+
+from .paper_runner import PaperRunConfig, run_paper_smoke
+
+__all__ = ["PaperRunConfig", "run_paper_smoke"]

--- a/src/paper/cli_paper.py
+++ b/src/paper/cli_paper.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+from paper.paper_runner import PaperRunConfig, run_paper_smoke
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Paper runner smoke pipeline.")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--steps", type=int, default=200)
+    parser.add_argument("--restart-every", type=int, default=50)
+    args = parser.parse_args()
+
+    config = PaperRunConfig(
+        run_id=args.run_id,
+        steps=args.steps,
+        restart_every=args.restart_every,
+    )
+
+    try:
+        summary = run_paper_smoke(config)
+        print(summary)
+        return 0
+    except RuntimeError:
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/paper/paper_runner.py
+++ b/src/paper/paper_runner.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from audit.decision_records import DecisionRecordWriter, ensure_run_dir, infer_next_seq_from_jsonl
+from audit.replay import replay_verify
+from selector.selector import select_strategy
+
+
+@dataclass(frozen=True)
+class PaperRunConfig:
+    run_id: str
+    timeframe: str = "1m"
+    steps: int = 200
+    restart_every: int = 50
+    out_dir: str = "runs"
+
+
+def generate_mock_market_state(i: int) -> dict:
+    if i % 4 == 0:
+        return {"trend_state": "UP"}
+    if i % 4 == 1:
+        return {"trend_state": "DOWN"}
+    if i % 4 == 2:
+        return {"trend_state": "RANGE", "volatility_regime": "LOW"}
+    return {"volatility_regime": "HIGH", "momentum_state": "SPIKE"}
+
+
+def _writer_for_run(run_id: str, out_dir: str) -> tuple[DecisionRecordWriter, str]:
+    base = Path(out_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    cwd = Path.cwd()
+    try:
+        os.chdir(base)
+        records_path = str(Path(ensure_run_dir(run_id)).resolve())
+    finally:
+        os.chdir(cwd)
+    next_seq = infer_next_seq_from_jsonl(records_path)
+    writer = DecisionRecordWriter(out_path=records_path, run_id=run_id, start_seq=next_seq)
+    return writer, records_path
+
+
+def run_paper_smoke(config: PaperRunConfig) -> dict:
+    writer, records_path = _writer_for_run(config.run_id, config.out_dir)
+
+    for step in range(config.steps):
+        market_state = generate_mock_market_state(step)
+        if step % 10 == 0:
+            risk_state = "RED"
+        elif step % 5 == 0:
+            risk_state = "YELLOW"
+        else:
+            risk_state = "GREEN"
+
+        select_strategy(
+            market_state=market_state,
+            risk_state=risk_state,
+            timeframe=config.timeframe,
+            record_writer=writer,
+        )
+
+        if config.restart_every > 0 and (step + 1) % config.restart_every == 0:
+            writer.close()
+            writer, records_path = _writer_for_run(config.run_id, config.out_dir)
+
+    writer.close()
+
+    replay_result = replay_verify(records_path=records_path)
+    if replay_result.mismatched > 0 or replay_result.hash_mismatch > 0:
+        raise RuntimeError("replay_verification_failed")
+
+    return {
+        "records_path": records_path,
+        "total": replay_result.total,
+        "matched": replay_result.matched,
+        "mismatched": replay_result.mismatched,
+        "hash_mismatch": replay_result.hash_mismatch,
+        "errors": replay_result.errors,
+    }

--- a/tests/test_paper_runner_b4.py
+++ b/tests/test_paper_runner_b4.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from paper.paper_runner import PaperRunConfig, run_paper_smoke
+
+
+def _load_valid_records(path: Path) -> list[dict]:
+    records = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def test_paper_smoke_end_to_end(tmp_path: Path) -> None:
+    config = PaperRunConfig(
+        run_id="smoke",
+        steps=40,
+        restart_every=10,
+        out_dir=str(tmp_path),
+    )
+    summary = run_paper_smoke(config)
+    records_path = Path(summary["records_path"])
+    assert records_path.exists()
+    assert summary["mismatched"] == 0
+    assert summary["hash_mismatch"] == 0
+    assert len(_load_valid_records(records_path)) >= config.steps
+
+
+def test_paper_restart_continues_seq(tmp_path: Path) -> None:
+    config = PaperRunConfig(
+        run_id="seqtest",
+        steps=25,
+        restart_every=5,
+        out_dir=str(tmp_path),
+    )
+    summary = run_paper_smoke(config)
+    records_path = Path(summary["records_path"])
+    records = _load_valid_records(records_path)
+    seqs = [record["seq"] for record in records]
+    assert seqs[0] == 0
+    assert all(seqs[i] <= seqs[i + 1] for i in range(len(seqs) - 1))
+    assert len(seqs) == config.steps


### PR DESCRIPTION
## Summary
Adds Phase 1(B) Step B4: a smoke paper runner that generates deterministic mock market_state, logs decision_records, simulates restarts, and verifies determinism via replay.

## What’s included
- Deterministic mock market_state generator
- Paper smoke runner with restart loop and restart-safe seq continuation
- CLI entrypoint for local runs
- Tests validating end-to-end pipeline and seq continuity

## Not included
- No real market data feed
- No live or paper execution of trades
- No UI

## Verification
- \`ruff check .\` PASS
- \`pytest -q\` PASS"