### PR TITLE
B6: Market state feed input for long-run harness

### DIFF
--- a/src/paper/cli_long_run.py
+++ b/src/paper/cli_long_run.py
@@ -12,6 +12,7 @@ def main() -> int:
     parser.add_argument("--restart-every-seconds", type=int, default=300)
     parser.add_argument("--rotate-every-records", type=int, default=5000)
     parser.add_argument("--replay-every-records", type=int, default=2000)
+    parser.add_argument("--feed", type=str, default=None)
     args = parser.parse_args()
 
     config = LongRunConfig(
@@ -20,6 +21,7 @@ def main() -> int:
         restart_every_seconds=args.restart_every_seconds,
         rotate_every_records=args.rotate_every_records,
         replay_every_records=args.replay_every_records,
+        feed_path=args.feed,
     )
 
     try:

--- a/src/paper/market_state_feed.py
+++ b/src/paper/market_state_feed.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+
+@dataclass
+class MarketStateFeed:
+    path: str
+    items: list[dict] = field(default_factory=list)
+    errors: int = 0
+
+    def __iter__(self) -> Iterator[dict]:
+        return iter(self.items)
+
+
+def load_market_state_feed(path: str) -> MarketStateFeed:
+    feed = MarketStateFeed(path=path)
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            feed.errors += 1
+            continue
+        if not isinstance(obj, dict):
+            feed.errors += 1
+            continue
+        feed.items.append(obj)
+    return feed
+
+
+def cycling_feed(iterable: Iterator[dict]) -> Iterator[dict]:
+    items = list(iterable)
+    if not items:
+        while True:
+            yield {}
+    while True:
+        for item in items:
+            yield item

--- a/tests/test_market_state_feed_b6.py
+++ b/tests/test_market_state_feed_b6.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from paper.long_run import LongRunConfig, run_long_paper
+from paper.market_state_feed import load_market_state_feed
+
+
+def test_feed_skips_corrupt_lines(tmp_path: Path) -> None:
+    path = tmp_path / "feed.jsonl"
+    lines = [
+        json.dumps({"trend_state": "UP"}),
+        "{bad json",
+        json.dumps(123),
+        json.dumps({"trend_state": "RANGE", "volatility_regime": "LOW"}),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    feed = load_market_state_feed(str(path))
+    assert len(feed.items) == 2
+
+
+def test_long_run_with_feed(tmp_path: Path) -> None:
+    path = tmp_path / "feed.jsonl"
+    lines = [
+        json.dumps({"trend_state": "UP"}),
+        json.dumps({"trend_state": "DOWN"}),
+        json.dumps({"trend_state": "RANGE", "volatility_regime": "LOW"}),
+        json.dumps({"volatility_regime": "HIGH", "momentum_state": "SPIKE"}),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    config = LongRunConfig(
+        run_id="feedrun",
+        duration_seconds=2,
+        restart_every_seconds=1,
+        rotate_every_records=10,
+        replay_every_records=7,
+        out_dir=str(tmp_path),
+        feed_path=str(path),
+    )
+    summary = run_long_paper(config)
+    assert summary["mismatched"] == 0
+    assert summary["hash_mismatch"] == 0
+    run_dir = Path(summary["records_path"])
+    assert list(run_dir.glob("decision_records_*.jsonl"))


### PR DESCRIPTION
## Summary
Adds Phase 1(B) Step B6: a JSONL market_state feed reader and integrates it into the long-run harness to replace mock inputs when provided.

## What’s included
- Robust JSONL feed reader (skips corrupt/non-dict lines)
- Optional feed input for long-run runner and CLI flag
- Tests for corruption tolerance and end-to-end long-run with feed

## Not included
- No real market data ingestion
- No trade execution
- No UI

## Verification
- \`ruff check .\` PASS
- \`pytest -q\` PASS