### PR TITLE
B7: Long-run feed generator and audit report tooling

### DIFF
--- a/docs/long_run_playbook.md
+++ b/docs/long_run_playbook.md
@@ -1,0 +1,36 @@
+# Long-run Playbook
+
+This playbook shows how to run a long paper harness with a large market_state feed and generate an audit summary.
+
+## 1) Generate a large feed
+
+```bash
+python -m src.paper.feed_generate --out runs/feeds/feed_500k.jsonl --rows 500000 --seed 42
+```
+
+## 2) Run long paper harness (example: 6 hours)
+
+```bash
+python -m src.paper.cli_long_run \
+  --run-id longrun_001 \
+  --duration-seconds 21600 \
+  --restart-every-seconds 900 \
+  --rotate-every-records 50000 \
+  --replay-every-records 20000 \
+  --feed runs/feeds/feed_500k.jsonl
+```
+
+## 3) Generate audit summary
+
+```bash
+python -m src.audit.report_decisions \
+  --run-dir runs/longrun_001 \
+  --out runs/longrun_001/summary.json
+```
+
+## 4) Acceptance criteria
+
+- summary.json exists
+- replay_verification.mismatched == 0
+- replay_verification.hash_mismatch == 0
+- replay_verification.errors == 0

--- a/src/audit/report_decisions.py
+++ b/src/audit/report_decisions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+from audit.replay import replay_verify
+
+
+def _iter_records(run_dir: Path) -> list[dict]:
+    records: list[dict] = []
+    for shard in sorted(run_dir.glob("decision_records_*.jsonl")):
+        for line in shard.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def build_summary(run_dir: Path) -> dict:
+    records = _iter_records(run_dir)
+    shards = list(run_dir.glob("decision_records_*.jsonl"))
+    risk_counts: Counter[str] = Counter()
+    strategy_counts: Counter[str] = Counter()
+    none_count = 0
+    ts_values: list[str] = []
+
+    for record in records:
+        risk_state = record.get("risk_state", "")
+        risk_counts[risk_state] += 1
+        selection = record.get("selection", {})
+        strategy_id = selection.get("strategy_id")
+        if strategy_id is None:
+            continue
+        strategy_counts[strategy_id] += 1
+        if strategy_id == "NONE":
+            none_count += 1
+        ts = record.get("ts_utc")
+        if isinstance(ts, str):
+            ts_values.append(ts)
+
+    replay_totals = {
+        "total": 0,
+        "matched": 0,
+        "mismatched": 0,
+        "hash_mismatch": 0,
+        "errors": 0,
+    }
+    for shard in sorted(shards):
+        result = replay_verify(records_path=str(shard))
+        replay_totals["total"] += result.total
+        replay_totals["matched"] += result.matched
+        replay_totals["mismatched"] += result.mismatched
+        replay_totals["hash_mismatch"] += result.hash_mismatch
+        replay_totals["errors"] += result.errors
+
+    summary = {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "total_records": len(records),
+        "shards_count": len(shards),
+        "risk_state_counts": dict(risk_counts),
+        "strategy_id_counts": dict(strategy_counts),
+        "none_count": none_count,
+        "first_ts": min(ts_values) if ts_values else None,
+        "last_ts": max(ts_values) if ts_values else None,
+        "replay_verification": replay_totals,
+    }
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize decision_records shards.")
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    out_path = Path(args.out)
+    summary = build_summary(run_dir)
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/paper/feed_generate.py
+++ b/src/paper/feed_generate.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+
+def _random_choice(rng: random.Random, options: list[tuple[str, int]]) -> str:
+    total = sum(weight for _, weight in options)
+    roll = rng.randint(1, total)
+    cumulative = 0
+    for value, weight in options:
+        cumulative += weight
+        if roll <= cumulative:
+            return value
+    return options[-1][0]
+
+
+def generate_market_state(rng: random.Random) -> dict:
+    trend_state = _random_choice(rng, [("UP", 30), ("DOWN", 30), ("RANGE", 40)])
+    volatility_regime = _random_choice(rng, [("LOW", 25), ("HIGH", 25), ("EXPANDING", 50)])
+    momentum_state = "SPIKE" if rng.random() < 0.05 else "NORMAL"
+    market_state: dict[str, str] = {
+        "trend_state": trend_state,
+        "volatility_regime": volatility_regime,
+        "momentum_state": momentum_state,
+    }
+    if rng.random() < 0.4:
+        market_state["range_state"] = _random_choice(rng, [("TIGHT", 50), ("WIDE", 50)])
+    return market_state
+
+
+def write_feed(out_path: Path, rows: int, seed: int, flush_every: int = 1000) -> None:
+    rng = random.Random(seed)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as handle:
+        for idx in range(rows):
+            record = generate_market_state(rng)
+            handle.write(json.dumps(record, separators=(",", ":"), ensure_ascii=False))
+            handle.write("\n")
+            if (idx + 1) % flush_every == 0:
+                handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate deterministic market_state JSONL feed.")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--rows", type=int, default=500000)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    write_feed(Path(args.out), args.rows, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_b7_reporting.py
+++ b/tests/test_b7_reporting.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from audit.report_decisions import build_summary
+from paper.feed_generate import write_feed
+from paper.long_run import LongRunConfig, run_long_paper
+
+
+def test_feed_generate_deterministic(tmp_path: Path) -> None:
+    path_a = tmp_path / "feed_a.jsonl"
+    path_b = tmp_path / "feed_b.jsonl"
+    write_feed(path_a, rows=1000, seed=42)
+    write_feed(path_b, rows=1000, seed=42)
+    assert path_a.read_bytes() == path_b.read_bytes()
+
+
+def test_report_decisions_counts(tmp_path: Path) -> None:
+    config = LongRunConfig(
+        run_id="reporting",
+        duration_seconds=2,
+        restart_every_seconds=1,
+        rotate_every_records=10,
+        replay_every_records=7,
+        out_dir=str(tmp_path),
+    )
+    summary = run_long_paper(config)
+    run_dir = Path(summary["records_path"])
+    report = build_summary(run_dir)
+    assert report["total_records"] > 0
+    assert report["strategy_id_counts"]


### PR DESCRIPTION
## Summary
Adds Phase 1(B) Step B7 tooling: deterministic market_state feed generator and decision_records audit reporting for long-run paper runs.

## What’s included
- Deterministic JSONL feed generator (seeded)
- Decision_records shard report tool (counts + replay verification)
- Playbook doc to run a multi-hour paper run and produce summary.json
- Tests for determinism and report correctness

## Not included
- No real OHLCV ingestion
- No trading execution
- No UI

## Verification
- \`ruff check .\` PASS
- \`pytest -q\` PASS