### PR TITLE
feat: add control plane, strategy registry, paper execution skeleton,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ See GITHUB_SETTINGS_CHECKLIST.md for required GitHub UI settings.
 
 See SECURITY.md for disclosure and secrets policy. The project forbids prediction or
 signal logic and requires deterministic, auditable changes.
+
+## Control Plane (arming / kill switch)
+
+Execution is gated by an explicit control plane. You must arm the system with
+approved inputs before any paper execution can run. A kill switch always disarms.
+
+Example (code):
+
+```python
+from control_plane.control import arm
+from control_plane.state import ControlConfig, Environment
+
+state = arm(ControlConfig(environment=Environment.PAPER, required_approvals={"ok"}), approvals=["ok"])
+```
+
+Paper execution writes `decision_records.jsonl` under `workspaces/<run_id>/`.
 ## End-to-End Flow
 
 Data -> Features -> Risk -> Strategy Selection -> Execution

--- a/src/control_plane/__init__.py
+++ b/src/control_plane/__init__.py
@@ -1,5 +1,16 @@
-"""Control plane for arming/disarming and execution gating."""
+from .control import arm, disarm, kill_switch, require_armed
+from .persistence import load_state, save_state
+from .state import ControlConfig, ControlState, Environment, SystemState
 
-from .core import ControlPlane, ControlPlaneState
-
-__all__ = ["ControlPlane", "ControlPlaneState"]
+__all__ = [
+    "arm",
+    "disarm",
+    "kill_switch",
+    "require_armed",
+    "load_state",
+    "save_state",
+    "ControlConfig",
+    "ControlState",
+    "Environment",
+    "SystemState",
+]

--- a/src/control_plane/control.py
+++ b/src/control_plane/control.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .state import ControlConfig, ControlState, SystemState
+
+
+def arm(config: ControlConfig, approvals: Iterable[str]) -> ControlState:
+    tokens = set(approvals)
+    missing = config.required_approvals - tokens
+    if missing:
+        raise ValueError(f"missing_approvals:{sorted(missing)}")
+    return ControlState(
+        state=SystemState.ARMED,
+        environment=config.environment,
+        approvals=tokens,
+        reason="armed",
+    )
+
+
+def disarm(reason: str) -> ControlState:
+    return ControlState(state=SystemState.DISARMED, reason=reason)
+
+
+def require_armed(state: ControlState) -> None:
+    if state.state != SystemState.ARMED:
+        raise RuntimeError("control_not_armed")
+
+
+def kill_switch(state: ControlState, reason: str) -> ControlState:
+    return ControlState(
+        state=SystemState.DISARMED,
+        environment=state.environment,
+        approvals=state.approvals,
+        reason=reason or "kill_switch",
+    )

--- a/src/control_plane/persistence.py
+++ b/src/control_plane/persistence.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from .state import ControlState, Environment, SystemState
+
+
+def _default_path() -> Path:
+    return Path(".buff") / "control_state.json"
+
+
+def save_state(state: ControlState, path: Path | None = None) -> None:
+    path = path or _default_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(state)
+    payload["state"] = state.state.value
+    payload["environment"] = state.environment.value
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def load_state(path: Path | None = None) -> ControlState:
+    path = path or _default_path()
+    if not path.exists():
+        return ControlState()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return ControlState(
+        state=SystemState(data.get("state", SystemState.DISARMED.value)),
+        environment=Environment(data.get("environment", Environment.PAPER.value)),
+        approvals=set(data.get("approvals", [])),
+        reason=data.get("reason"),
+    )

--- a/src/control_plane/state.py
+++ b/src/control_plane/state.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class SystemState(str, Enum):
+    DISARMED = "DISARMED"
+    ARMED = "ARMED"
+
+
+class Environment(str, Enum):
+    PAPER = "PAPER"
+    LIVE = "LIVE"
+
+
+@dataclass(frozen=True)
+class ControlConfig:
+    environment: Environment = Environment.PAPER
+    required_approvals: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class ControlState:
+    state: SystemState = SystemState.DISARMED
+    environment: Environment = Environment.PAPER
+    approvals: set[str] = field(default_factory=set)
+    reason: str | None = None

--- a/src/strategy_registry/__init__.py
+++ b/src/strategy_registry/__init__.py
@@ -1,0 +1,10 @@
+from .registry import StrategySpec, get_strategy, list_strategies, register_strategy
+from .selector import select_strategy
+
+__all__ = [
+    "StrategySpec",
+    "register_strategy",
+    "list_strategies",
+    "get_strategy",
+    "select_strategy",
+]

--- a/src/strategy_registry/registry.py
+++ b/src/strategy_registry/registry.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StrategySpec:
+    name: str
+    version: str
+    description: str
+    required_features: list[str]
+
+
+_REGISTRY: list[StrategySpec] = []
+
+
+def register_strategy(spec: StrategySpec) -> None:
+    if any(item.name == spec.name and item.version == spec.version for item in _REGISTRY):
+        raise ValueError("strategy_already_registered")
+    _REGISTRY.append(spec)
+
+
+def list_strategies() -> list[StrategySpec]:
+    return sorted(_REGISTRY, key=lambda item: (item.name, item.version))
+
+
+def get_strategy(name: str) -> StrategySpec:
+    matches = [item for item in _REGISTRY if item.name == name]
+    if not matches:
+        raise ValueError("strategy_not_found")
+    if len(matches) > 1:
+        raise ValueError("strategy_name_ambiguous")
+    return matches[0]
+
+
+def _reset_registry() -> None:
+    _REGISTRY.clear()

--- a/src/strategy_registry/selector.py
+++ b/src/strategy_registry/selector.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .registry import StrategySpec, get_strategy
+
+
+def select_strategy(menu_choice: str, registry: Iterable[StrategySpec] | None = None) -> StrategySpec:
+    if registry is None:
+        return get_strategy(menu_choice)
+    candidates = [spec for spec in registry if spec.name == menu_choice]
+    if not candidates:
+        raise ValueError("strategy_not_found")
+    if len(candidates) > 1:
+        raise ValueError("strategy_name_ambiguous")
+    return candidates[0]

--- a/tests/control_plane/test_control_plane_state.py
+++ b/tests/control_plane/test_control_plane_state.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from control_plane.control import arm, kill_switch, require_armed
+from control_plane.state import ControlConfig, ControlState, SystemState
+
+
+def test_require_armed_raises() -> None:
+    state = ControlState(state=SystemState.DISARMED)
+    with pytest.raises(RuntimeError):
+        require_armed(state)
+
+
+def test_arm_requires_approvals() -> None:
+    config = ControlConfig(required_approvals={"approved"})
+    with pytest.raises(ValueError):
+        arm(config, approvals=[])
+    armed = arm(config, approvals=["approved"])
+    assert armed.state == SystemState.ARMED
+
+
+def test_kill_switch_disarms() -> None:
+    state = ControlState(state=SystemState.ARMED)
+    killed = kill_switch(state, "manual")
+    assert killed.state == SystemState.DISARMED

--- a/tests/execution/test_paper_engine.py
+++ b/tests/execution/test_paper_engine.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from control_plane.state import ControlState, SystemState
+from execution.engine import execute_paper_run
+
+
+def test_disarmed_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(RuntimeError):
+        execute_paper_run(
+            input_data={"run_id": "run1", "timeframe": "1m"},
+            features={},
+            risk_decision={"risk_state": "GREEN"},
+            selected_strategy={"strategy_id": "s1"},
+            control_state=ControlState(state=SystemState.DISARMED),
+        )
+
+
+def test_risk_red_blocks_and_records(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    out = execute_paper_run(
+        input_data={"run_id": "run1", "timeframe": "1m", "market_state": {}},
+        features={},
+        risk_decision={"risk_state": "RED"},
+        selected_strategy={"strategy_id": "s1"},
+        control_state=ControlState(state=SystemState.ARMED),
+    )
+    assert out["status"] == "blocked"
+    path = Path("workspaces") / "run1" / "decision_records.jsonl"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["selection"]["status"] == "blocked"
+
+
+def test_armed_green_writes_record(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    out = execute_paper_run(
+        input_data={"run_id": "run1", "timeframe": "1m", "market_state": {}},
+        features={},
+        risk_decision={"risk_state": "GREEN"},
+        selected_strategy={"strategy_id": "s1"},
+        control_state=ControlState(state=SystemState.ARMED),
+    )
+    assert out["status"] == "ok"
+    path = Path("workspaces") / "run1" / "decision_records.jsonl"
+    assert path.exists()

--- a/tests/strategy_registry/test_registry.py
+++ b/tests/strategy_registry/test_registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from strategy_registry.registry import StrategySpec, _reset_registry, register_strategy, list_strategies
+from strategy_registry.selector import select_strategy
+
+
+def test_registry_deterministic_order() -> None:
+    _reset_registry()
+    register_strategy(
+        StrategySpec(
+            name="beta",
+            version="1.0.0",
+            description="beta",
+            required_features=["a"],
+        )
+    )
+    register_strategy(
+        StrategySpec(
+            name="alpha",
+            version="1.0.0",
+            description="alpha",
+            required_features=["b"],
+        )
+    )
+    names = [spec.name for spec in list_strategies()]
+    assert names == ["alpha", "beta"]
+
+
+def test_select_unknown_strategy() -> None:
+    with pytest.raises(ValueError):
+        select_strategy("missing", registry=[])

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from control_plane.control import arm
+from control_plane.state import ControlConfig, Environment, SystemState
+from execution.engine import execute_paper_run
+from strategy_registry.registry import StrategySpec, _reset_registry, register_strategy
+
+
+def test_e2e_pipeline_writes_decision_record(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _reset_registry()
+    register_strategy(
+        StrategySpec(
+            name="dummy",
+            version="1.0.0",
+            description="dummy",
+            required_features=["close"],
+        )
+    )
+
+    _ = pd.DataFrame(
+        {
+            "ts": pd.date_range("2023-01-01", periods=3, freq="1min", tz="UTC"),
+            "open": [1.0, 1.0, 1.0],
+            "high": [1.0, 1.0, 1.0],
+            "low": [1.0, 1.0, 1.0],
+            "close": [1.0, 1.0, 1.0],
+            "volume": [1.0, 1.0, 1.0],
+        }
+    )
+
+    control_state = arm(
+        ControlConfig(environment=Environment.PAPER, required_approvals={"ok"}),
+        approvals=["ok"],
+    )
+    assert control_state.state == SystemState.ARMED
+
+    out = execute_paper_run(
+        input_data={
+            "run_id": "e2e",
+            "timeframe": "1m",
+            "market_state": {"trend_state": "UP"},
+        },
+        features={"close": [1.0, 1.0, 1.0]},
+        risk_decision={"risk_state": "GREEN"},
+        selected_strategy={"strategy_id": "dummy"},
+        control_state=control_state,
+    )
+    assert out["status"] == "ok"
+
+    records_path = Path("workspaces") / "e2e" / "decision_records.jsonl"
+    lines = records_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["schema_version"] == "dr.v1"
+    assert "selection" in record


### PR DESCRIPTION
Adds a minimal but strict runtime skeleton:
- Control Plane with arm/disarm/kill-switch and persisted state
- Deterministic Strategy Registry (no invention)
- Fail-closed paper execution with audit trail (decision_records.jsonl)
- Unit tests for all new components
- End-to-end pipeline test (data → risk → strategy → execution)

No price prediction, no buy/sell logic, no live execution.
All behavior is deterministic and auditable.
