### PR TITLE
Docs: WIP documentation cleanup (part 1) (refs #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,6 @@ python -m src.cli report --run-id <id> --workspaces workspaces --last-n 50
 python -m src.cli validate-run --run-id <id> --workspaces workspaces
 ```
 
-## Golden fixtures + E2E CLI verification (M4.7)
-
-End-to-end tests generate small deterministic workspace fixtures on the fly.
-No workspace fixtures are committed to the repo.
-
 ## Chatbot Read-Only Artifact Navigator (M4.5)
 
 Provides deterministic, read-only lookup of audit artifacts for a given run.


### PR DESCRIPTION
## Summary
- Docs-only cleanup extracted from archived WIP
- Removes outdated README instructions
- No code, config, or behavior changes

Refs: #34

