### PR TITLE
M6: add idempotency keying and dedupe protection

### DIFF
--- a/src/execution/idempotency.py
+++ b/src/execution/idempotency.py
@@ -1,16 +1,52 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from execution.types import OrderIntent
+
+
+def _utc_now_z() -> str:
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return ts.replace("+00:00", "Z")
+
+
+def make_idempotency_key(intent: OrderIntent, *, run_id: str | None = None) -> str:
+    """Derive a stable idempotency key from intent.intent_hash and optional run scope."""
+
+    base = intent.intent_hash()
+    return f"{run_id}:{base}" if run_id else base
 
 
 @dataclass
 class IdempotencyStore:
-    """In-memory idempotency store."""
+    """In-memory idempotency store for dedupe protection."""
 
-    seen_event_ids: set[str] = field(default_factory=set)
+    records: dict[str, Mapping[str, Any]] = field(default_factory=dict)
 
-    def seen(self, event_id: str) -> bool:
-        return event_id in self.seen_event_ids
+    def has(self, key: str) -> bool:
+        return key in self.records
 
-    def mark(self, event_id: str) -> None:
-        self.seen_event_ids.add(event_id)
+    def get(self, key: str) -> Mapping[str, Any]:
+        return self.records[key]
+
+    def put(self, key: str, record: Mapping[str, Any]) -> None:
+        self.records[key] = dict(record)
+
+
+def build_idempotency_record(
+    *,
+    status: str,
+    order_id: str | None,
+    audit_ref: str | None,
+    decision: Mapping[str, Any],
+    timestamp_utc: str | None = None,
+) -> Mapping[str, Any]:
+    return {
+        "status": status,
+        "order_id": order_id,
+        "timestamp_utc": timestamp_utc or _utc_now_z(),
+        "audit_ref": audit_ref,
+        "decision": dict(decision),
+    }

--- a/src/execution/types.py
+++ b/src/execution/types.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Mapping
 
+from audit.schema import canonical_json, sha256_hex
+
 from risk.types import RiskState, Permission
 
 
@@ -31,6 +33,20 @@ class OrderIntent:
     leverage: float
     protective_exit_required: bool
     metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def intent_hash(self) -> str:
+        """Deterministic payload hash (excludes event_id and intent_id)."""
+
+        payload = {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "side": self.side.value,
+            "quantity": self.quantity,
+            "leverage": self.leverage,
+            "protective_exit_required": self.protective_exit_required,
+            "metadata": dict(self.metadata),
+        }
+        return sha256_hex(canonical_json(payload))
 
 
 @dataclass(frozen=True)

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from execution.audit import DecisionWriter
+from execution.brokers import PaperBroker
+from execution.engine import ExecutionEngine
+from execution.idempotency import IdempotencyStore
+from execution.locks import RiskLocks
+from execution.types import IntentSide, OrderIntent
+from risk.contracts import RiskInputs
+from risk.state_machine import RiskConfig, RiskState
+from risk.types import Permission
+
+
+pytestmark = pytest.mark.unit
+
+
+def _locks() -> RiskLocks:
+    return RiskLocks(
+        max_exposure=10.0,
+        max_trades_per_day=5,
+        leverage_cap=3.0,
+        kill_switch=False,
+        mandatory_protective_exit=True,
+    )
+
+
+def _risk_inputs() -> RiskInputs:
+    return RiskInputs(
+        symbol="BTCUSDT",
+        timeframe="1h",
+        as_of="2024-01-01T00:00:00+00:00",
+        atr_pct=0.005,
+        realized_vol=0.005,
+        missing_fraction=0.0,
+        timestamps_valid=True,
+        latest_metrics_valid=True,
+        invalid_index=False,
+        invalid_close=False,
+    )
+
+
+def _risk_config() -> RiskConfig:
+    return RiskConfig(
+        missing_red=0.2, atr_yellow=0.02, atr_red=0.05, rvol_yellow=0.02, rvol_red=0.05
+    )
+
+
+def _intent(event_id: str, qty: float = 1.0) -> OrderIntent:
+    return OrderIntent(
+        event_id=event_id,
+        intent_id=f"intent-{event_id}",
+        symbol="BTCUSDT",
+        timeframe="1h",
+        side=IntentSide.LONG,
+        quantity=qty,
+        leverage=1.0,
+        protective_exit_required=True,
+    )
+
+
+def _engine(tmp_path: Path) -> tuple[ExecutionEngine, PaperBroker]:
+    broker = PaperBroker()
+    engine = ExecutionEngine(
+        broker=broker,
+        decision_writer=DecisionWriter(tmp_path / "decision.jsonl"),
+        idempotency=IdempotencyStore(),
+    )
+    return engine, broker
+
+
+def test_dedup_same_intent(tmp_path: Path) -> None:
+    engine, broker = _engine(tmp_path)
+    intent = _intent("evt-1")
+    engine.handle_intent(
+        intent=intent,
+        risk_state=RiskState.GREEN,
+        permission=Permission.ALLOW,
+        risk_inputs=_risk_inputs(),
+        risk_config=_risk_config(),
+        locks=_locks(),
+        current_exposure=0.0,
+        trades_today=0,
+        data_snapshot_hash="data",
+        feature_snapshot_hash="features",
+        strategy_id="strat-1",
+    )
+    engine.handle_intent(
+        intent=intent,
+        risk_state=RiskState.GREEN,
+        permission=Permission.ALLOW,
+        risk_inputs=_risk_inputs(),
+        risk_config=_risk_config(),
+        locks=_locks(),
+        current_exposure=0.0,
+        trades_today=0,
+        data_snapshot_hash="data",
+        feature_snapshot_hash="features",
+        strategy_id="strat-1",
+    )
+    assert len(broker.submitted) == 1
+
+
+def test_dedup_diff_intent_qty(tmp_path: Path) -> None:
+    engine, broker = _engine(tmp_path)
+    engine.handle_intent(
+        intent=_intent("evt-1", qty=1.0),
+        risk_state=RiskState.GREEN,
+        permission=Permission.ALLOW,
+        risk_inputs=_risk_inputs(),
+        risk_config=_risk_config(),
+        locks=_locks(),
+        current_exposure=0.0,
+        trades_today=0,
+        data_snapshot_hash="data",
+        feature_snapshot_hash="features",
+        strategy_id="strat-1",
+    )
+    engine.handle_intent(
+        intent=_intent("evt-2", qty=2.0),
+        risk_state=RiskState.GREEN,
+        permission=Permission.ALLOW,
+        risk_inputs=_risk_inputs(),
+        risk_config=_risk_config(),
+        locks=_locks(),
+        current_exposure=0.0,
+        trades_today=0,
+        data_snapshot_hash="data",
+        feature_snapshot_hash="features",
+        strategy_id="strat-1",
+    )
+    assert len(broker.submitted) == 2
+
+
+def test_store_failure_blocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, broker = _engine(tmp_path)
+
+    def _boom(_key: str) -> bool:
+        raise RuntimeError("store_down")
+
+    monkeypatch.setattr(engine.idempotency, "has", _boom)
+    decision = engine.handle_intent(
+        intent=_intent("evt-3"),
+        risk_state=RiskState.GREEN,
+        permission=Permission.ALLOW,
+        risk_inputs=_risk_inputs(),
+        risk_config=_risk_config(),
+        locks=_locks(),
+        current_exposure=0.0,
+        trades_today=0,
+        data_snapshot_hash="data",
+        feature_snapshot_hash="features",
+        strategy_id="strat-1",
+    )
+    assert decision.action == "blocked"
+    assert decision.reason == "idempotency_error"
+    assert broker.submitted == []


### PR DESCRIPTION
Adds deterministic idempotency keying using intent.intent_hash (+ optional run_id scope) and dedupe protection in the paper execution flow.

- Key derivation: intent.intent_hash (payload-stable, excludes event_id/intent_id) + optional run_id
- Duplicate handling: returns stored decision, no broker submit
- Fail-closed: store read/write errors block execution (idempotency_error)

Closes #44
