### PR TITLE
test: remove pandas deprecation and zip duplicate warnings

### DIFF
--- a/tests/integration/test_run_ingest_offline.py
+++ b/tests/integration/test_run_ingest_offline.py
@@ -66,7 +66,7 @@ def test_parquet_has_utc_timestamps(tmp_path):
     loaded = load_parquet(str(parquet_path))
 
     assert "ts" in loaded.columns
-    assert pd.api.types.is_datetime64tz_dtype(loaded["ts"])
+    assert isinstance(loaded["ts"].dtype, pd.DatetimeTZDtype)
     assert loaded["ts"].is_monotonic_increasing
 
 


### PR DESCRIPTION
## What
- Replaced deprecated pandas dtype check with `isinstance(dtype, pd.DatetimeTZDtype)` in `tests/integration/test_run_ingest_offline.py`.
- Reworked zip tamper test to avoid duplicate `checksums.txt` entries while preserving tamper-detection intent in `tests/test_audit_verify.py`.

## Why
- Eliminate noisy warnings that can become future CI failures as dependencies evolve.
- Keep test output clean and signals meaningful.

## Verification
- ruff format .
- ruff check .
- pytest -q (307 passed, 1 skipped)

## Scope
- Tests-only change. No business logic changes.
