### PR TITLE
M2.5: deterministic regime semantics and strategy-family gating

### DIFF
--- a/docs/REGIME_SEMANTICS.md
+++ b/docs/REGIME_SEMANTICS.md
@@ -1,0 +1,43 @@
+﻿# Regime Semantics
+
+Regime semantics provide a deterministic permission layer. A regime is not a buy/sell signal; it only gates which strategy families are allowed to run.
+
+## Regimes (7)
+- RISK_OFF
+- HIGH_VOL_TREND
+- LOW_VOL_TREND
+- HIGH_VOL_RANGE
+- LOW_VOL_RANGE
+- MEAN_REVERSION_BIAS
+- NEUTRAL
+
+## Default thresholds (conservative, not optimized)
+- adx_trend_threshold: 25
+- adx_range_threshold: 20
+- high_atr_pct_threshold: 0.02
+- low_atr_pct_threshold: 0.01
+- realized_vol_high_threshold: 0.03
+- realized_vol_low_threshold: 0.015
+- risk_off_atr_pct_threshold: 0.03
+- risk_off_realized_vol_threshold: 0.05
+
+These are defaults used in `knowledge/regimes.yaml`. They are not tuned and should be revisited for new markets or timeframes.
+
+## Fail-closed rules
+- Missing required features (or NaNs) return `RISK_OFF` with `missing_features` in the summary.
+- No silent defaults are applied during evaluation.
+
+## Adding a new regime safely
+1) Add the regime to `knowledge/regimes.yaml` with a unique priority.
+2) Keep priorities strictly descending; `RISK_OFF` must be highest and `NEUTRAL` must be lowest.
+3) Use numeric, unambiguous conditions and only approved feature names.
+4) Update tests in `tests/unit` and add at least one explicit classification example.
+5) Re-run `ruff` and `pytest`.
+
+## Feature references
+Regime conditions must reference known indicator outputs and derived risk metrics, including:
+- adx_14, atr_pct, realized_vol_20 (alias: realized_vol)
+- rsi_14, rsi_slope_14_5
+- ema_spread_20_50
+- vwap_typical_daily
+- bb_upper_20_2, bb_lower_20_2

--- a/knowledge/regime_strategy_families.md
+++ b/knowledge/regime_strategy_families.md
@@ -1,0 +1,7 @@
+﻿# Regime Strategy Families
+
+- trend_following: Trend continuation systems that favor directional persistence.
+- breakout: Volatility expansion systems that trade range breaks without predicting direction.
+- mean_reversion: Reversal systems that fade extremes back toward a reference level.
+- market_making: Spread capture systems that provide liquidity in tight ranges.
+- do_not_trade: Explicit no-trade mode used for fail-closed or extreme regimes.

--- a/knowledge/regimes.yaml
+++ b/knowledge/regimes.yaml
@@ -1,0 +1,161 @@
+﻿schema_version: "1"
+feature_catalog:
+  - name: realized_vol_20
+    aliases:
+      - realized_vol
+    description: Rolling std dev of log returns over a 20-period window.
+regimes:
+  - regime_id: RISK_OFF
+    description: Extreme volatility or missing features; trading disabled.
+    priority: 100
+    conditions:
+      any:
+        - gte: { realized_vol_20: 0.05 }
+        - gte: { atr_pct: 0.03 }
+    allowed_strategy_families:
+      - do_not_trade
+    forbidden_strategy_families:
+      - trend_following
+      - breakout
+      - mean_reversion
+      - market_making
+    risk_modifiers:
+      max_position_size_scale: 0.0
+      trade_cooldown_minutes: 60
+    rationale:
+      - Extreme volatility triggers a no-trade posture.
+      - Fail-closed when required inputs are missing.
+  - regime_id: HIGH_VOL_TREND
+    description: Trending market with elevated volatility.
+    priority: 90
+    conditions:
+      all:
+        - gte: { adx_14: 25 }
+        - any:
+            - gte: { realized_vol_20: 0.03 }
+            - gte: { atr_pct: 0.02 }
+    allowed_strategy_families:
+      - trend_following
+      - breakout
+    forbidden_strategy_families:
+      - mean_reversion
+      - market_making
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 0.6
+      trade_cooldown_minutes: 15
+    rationale:
+      - Trend confirmed by ADX(14) >= 25.
+      - High volatility requires smaller sizing.
+  - regime_id: LOW_VOL_TREND
+    description: Trending market with subdued volatility.
+    priority: 80
+    conditions:
+      all:
+        - gte: { adx_14: 25 }
+        - lte: { atr_pct: 0.01 }
+        - lte: { realized_vol_20: 0.015 }
+    allowed_strategy_families:
+      - trend_following
+      - breakout
+    forbidden_strategy_families:
+      - mean_reversion
+      - market_making
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 1.0
+      trade_cooldown_minutes: 5
+    rationale:
+      - Trend confirmed by ADX(14) >= 25.
+      - Low volatility allows normal sizing.
+  - regime_id: HIGH_VOL_RANGE
+    description: Range-bound market with elevated volatility.
+    priority: 70
+    conditions:
+      all:
+        - lte: { adx_14: 20 }
+        - any:
+            - gte: { realized_vol_20: 0.03 }
+            - gte: { atr_pct: 0.02 }
+    allowed_strategy_families:
+      - mean_reversion
+    forbidden_strategy_families:
+      - trend_following
+      - breakout
+      - market_making
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 0.4
+      trade_cooldown_minutes: 20
+    rationale:
+      - Range regime indicated by ADX(14) <= 20.
+      - High volatility favors reduced exposure.
+  - regime_id: LOW_VOL_RANGE
+    description: Range-bound market with low volatility.
+    priority: 60
+    conditions:
+      all:
+        - lte: { adx_14: 20 }
+        - lte: { atr_pct: 0.01 }
+        - lte: { realized_vol_20: 0.015 }
+        - not:
+            any:
+              - lte: { rsi_14: 30 }
+              - gte: { rsi_14: 70 }
+    allowed_strategy_families:
+      - mean_reversion
+      - market_making
+    forbidden_strategy_families:
+      - trend_following
+      - breakout
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 0.8
+      trade_cooldown_minutes: 5
+    rationale:
+      - Range regime indicated by ADX(14) <= 20.
+      - RSI avoids extreme mean-reversion triggers.
+  - regime_id: MEAN_REVERSION_BIAS
+    description: Range with RSI extremes favoring mean reversion setups.
+    priority: 50
+    conditions:
+      all:
+        - lte: { adx_14: 20 }
+        - lte: { atr_pct: 0.015 }
+        - lte: { realized_vol_20: 0.02 }
+        - any:
+            - lte: { rsi_14: 30 }
+            - gte: { rsi_14: 70 }
+        - not:
+            abs_gt: { rsi_slope_14_5: 2.0 }
+        - not:
+            abs_gt: { ema_spread_20_50: 0.5 }
+        - gt: { vwap_typical_daily: 0 }
+        - gt: { bb_upper_20_2: 0 }
+        - gt: { bb_lower_20_2: 0 }
+    allowed_strategy_families:
+      - mean_reversion
+    forbidden_strategy_families:
+      - trend_following
+      - breakout
+      - market_making
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 0.7
+      trade_cooldown_minutes: 10
+    rationale:
+      - RSI extremes with muted slope indicate overshoot.
+      - VWAP/Bollinger levels must be available.
+  - regime_id: NEUTRAL
+    description: No specific regime match; default permissions.
+    priority: 0
+    allowed_strategy_families:
+      - trend_following
+      - breakout
+      - mean_reversion
+      - market_making
+    forbidden_strategy_families:
+      - do_not_trade
+    risk_modifiers:
+      max_position_size_scale: 1.0
+      trade_cooldown_minutes: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ccxt>=1.91.0",
     "pandas>=1.5.0",
+    "pydantic>=2.5.0",
     "pyarrow>=10.0.0",
     "PyYAML>=6.0",
 ]

--- a/src/buff/regimes/__init__.py
+++ b/src/buff/regimes/__init__.py
@@ -1,0 +1,13 @@
+"""Regime semantics: schema, parser, and evaluator."""
+
+from buff.regimes.evaluator import evaluate_regime
+from buff.regimes.parser import load_regime_config
+from buff.regimes.types import RegimeConfig, RegimeDecision, RegimeRule
+
+__all__ = [
+    "RegimeConfig",
+    "RegimeDecision",
+    "RegimeRule",
+    "evaluate_regime",
+    "load_regime_config",
+]

--- a/src/buff/regimes/errors.py
+++ b/src/buff/regimes/errors.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for regime semantics."""
+
+
+class RegimeError(Exception):
+    """Base exception for regime semantics."""
+
+
+class RegimeSchemaError(RegimeError):
+    """Raised when regime schema validation fails."""
+
+
+class RegimeEvaluationError(RegimeError):
+    """Raised when regime evaluation encounters an unrecoverable error."""

--- a/src/buff/regimes/evaluator.py
+++ b/src/buff/regimes/evaluator.py
@@ -1,0 +1,214 @@
+"""Evaluate regime rules against a feature snapshot."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+from buff.regimes.errors import RegimeEvaluationError
+from buff.regimes.schema import Condition
+from buff.regimes.types import RegimeConfig, RegimeDecision
+
+
+def evaluate_regime(
+    features: Mapping[str, Any],
+    config: RegimeConfig,
+) -> RegimeDecision:
+    resolved, missing = _resolve_required_features(features, config)
+    if missing:
+        return _fail_closed(config, missing)
+
+    for regime in config.regimes:
+        if regime.conditions is None:
+            return RegimeDecision(
+                regime_id=regime.regime_id,
+                matched_conditions_summary="default_match",
+                allowed_strategy_families=regime.allowed_strategy_families,
+                forbidden_strategy_families=regime.forbidden_strategy_families,
+                risk_modifiers=regime.risk_modifiers,
+            )
+        matched, summary = _evaluate_condition(regime.conditions, resolved)
+        if matched:
+            return RegimeDecision(
+                regime_id=regime.regime_id,
+                matched_conditions_summary=summary,
+                allowed_strategy_families=regime.allowed_strategy_families,
+                forbidden_strategy_families=regime.forbidden_strategy_families,
+                risk_modifiers=regime.risk_modifiers,
+            )
+
+    raise RegimeEvaluationError("no_regime_matched")
+
+
+def _fail_closed(config: RegimeConfig, missing: list[str]) -> RegimeDecision:
+    risk_off = next((regime for regime in config.regimes if regime.regime_id == "RISK_OFF"), None)
+    if risk_off is None:
+        raise RegimeEvaluationError("risk_off_missing")
+    summary = "missing_features:" + ",".join(sorted(missing))
+    return RegimeDecision(
+        regime_id=risk_off.regime_id,
+        matched_conditions_summary=summary,
+        allowed_strategy_families=risk_off.allowed_strategy_families,
+        forbidden_strategy_families=risk_off.forbidden_strategy_families,
+        risk_modifiers=risk_off.risk_modifiers,
+    )
+
+
+def _resolve_required_features(
+    features: Mapping[str, Any],
+    config: RegimeConfig,
+) -> tuple[dict[str, float], list[str]]:
+    resolved: dict[str, float] = {}
+    missing: list[str] = []
+    for name in config.required_features:
+        value = _resolve_feature_value(name, features, config)
+        if value is None:
+            missing.append(name)
+            continue
+        resolved[name] = value
+    return resolved, missing
+
+
+def _resolve_feature_value(
+    name: str,
+    features: Mapping[str, Any],
+    config: RegimeConfig,
+) -> float | None:
+    value = _coerce_numeric(features.get(name))
+    if value is not None:
+        return value
+
+    canonical = config.alias_to_canonical.get(name)
+    if canonical:
+        value = _coerce_numeric(features.get(canonical))
+        if value is not None:
+            return value
+        for alias in config.feature_aliases.get(canonical, ()):  # type: ignore[arg-type]
+            value = _coerce_numeric(features.get(alias))
+            if value is not None:
+                return value
+
+    for alias in config.feature_aliases.get(name, ()):  # type: ignore[arg-type]
+        value = _coerce_numeric(features.get(alias))
+        if value is not None:
+            return value
+
+    return None
+
+
+def _coerce_numeric(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+    else:
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return None
+    if math.isnan(numeric):
+        return None
+    return numeric
+
+
+def _evaluate_condition(condition: Condition, values: Mapping[str, float]) -> tuple[bool, str]:
+    op = condition.op
+    if op in {"gt", "gte", "lt", "lte", "abs_gt"}:
+        return _evaluate_numeric(condition, values)
+    if op == "between":
+        return _evaluate_between(condition, values)
+    if op in {"all", "any"}:
+        return _evaluate_group(condition, values)
+    if op == "not":
+        return _evaluate_not(condition, values)
+    raise RegimeEvaluationError(f"condition_operator_unknown:{op}")
+
+
+def _evaluate_numeric(condition: Condition, values: Mapping[str, float]) -> tuple[bool, str]:
+    feature = _require_feature(condition)
+    threshold = _require_value(condition)
+    actual = values[feature]
+    if condition.op == "gt":
+        matched = actual > threshold
+        desc = f"gt({feature}={_fmt(actual)}, threshold={_fmt(threshold)})"
+    elif condition.op == "gte":
+        matched = actual >= threshold
+        desc = f"gte({feature}={_fmt(actual)}, threshold={_fmt(threshold)})"
+    elif condition.op == "lt":
+        matched = actual < threshold
+        desc = f"lt({feature}={_fmt(actual)}, threshold={_fmt(threshold)})"
+    elif condition.op == "lte":
+        matched = actual <= threshold
+        desc = f"lte({feature}={_fmt(actual)}, threshold={_fmt(threshold)})"
+    elif condition.op == "abs_gt":
+        matched = abs(actual) > threshold
+        desc = f"abs_gt({feature}={_fmt(actual)}, threshold={_fmt(threshold)})"
+    else:
+        raise RegimeEvaluationError(f"condition_operator_unknown:{condition.op}")
+    return matched, _with_result(desc, matched)
+
+
+def _evaluate_between(condition: Condition, values: Mapping[str, float]) -> tuple[bool, str]:
+    feature = _require_feature(condition)
+    lower = _require_lower(condition)
+    upper = _require_upper(condition)
+    actual = values[feature]
+    matched = lower <= actual <= upper
+    desc = f"between({feature}={_fmt(actual)}, range=[{_fmt(lower)},{_fmt(upper)}])"
+    return matched, _with_result(desc, matched)
+
+
+def _evaluate_group(condition: Condition, values: Mapping[str, float]) -> tuple[bool, str]:
+    results: list[tuple[bool, str]] = []
+    for item in condition.items:
+        results.append(_evaluate_condition(item, values))
+    if condition.op == "all":
+        matched = all(result for result, _ in results)
+    else:
+        matched = any(result for result, _ in results)
+    joined = ", ".join(desc for _, desc in results)
+    desc = f"{condition.op}([{joined}])"
+    return matched, _with_result(desc, matched)
+
+
+def _evaluate_not(condition: Condition, values: Mapping[str, float]) -> tuple[bool, str]:
+    if not condition.items:
+        raise RegimeEvaluationError("condition_not_empty")
+    matched_child, desc_child = _evaluate_condition(condition.items[0], values)
+    matched = not matched_child
+    desc = f"not({desc_child})"
+    return matched, _with_result(desc, matched)
+
+
+def _require_feature(condition: Condition) -> str:
+    if condition.feature is None:
+        raise RegimeEvaluationError("condition_feature_missing")
+    return condition.feature
+
+
+def _require_value(condition: Condition) -> float:
+    if condition.value is None:
+        raise RegimeEvaluationError("condition_value_missing")
+    return condition.value
+
+
+def _require_lower(condition: Condition) -> float:
+    if condition.lower is None:
+        raise RegimeEvaluationError("condition_lower_missing")
+    return condition.lower
+
+
+def _require_upper(condition: Condition) -> float:
+    if condition.upper is None:
+        raise RegimeEvaluationError("condition_upper_missing")
+    return condition.upper
+
+
+def _with_result(desc: str, matched: bool) -> str:
+    return f"{desc}=>{matched}"
+
+
+def _fmt(value: float) -> str:
+    return f"{value:.6g}"

--- a/src/buff/regimes/parser.py
+++ b/src/buff/regimes/parser.py
@@ -1,0 +1,145 @@
+"""Load and validate regime rules from YAML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from buff.features.registry import FEATURES
+from buff.regimes.errors import RegimeSchemaError
+from buff.regimes.schema import RegimeSchema
+from buff.regimes.types import RegimeConfig, RegimeRule
+
+
+def load_regime_config(path: Path) -> RegimeConfig:
+    payload = _read_yaml(path)
+    try:
+        schema = RegimeSchema.model_validate(payload)
+    except ValidationError as exc:
+        raise RegimeSchemaError(f"schema_validation_failed: {exc}") from exc
+    return _normalize_schema(schema)
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise RegimeSchemaError(f"schema_not_found:{path}")
+    raw = path.read_text(encoding="utf-8")
+    payload = yaml.safe_load(raw)
+    if not isinstance(payload, dict):
+        raise RegimeSchemaError("schema_root_invalid")
+    return payload
+
+
+def _normalize_schema(schema: RegimeSchema) -> RegimeConfig:
+    if schema.schema_version != "1":
+        raise RegimeSchemaError("schema_version_unsupported")
+
+    if not schema.regimes:
+        raise RegimeSchemaError("regimes_missing")
+
+    regime_ids = [regime.regime_id for regime in schema.regimes]
+    if len(set(regime_ids)) != len(regime_ids):
+        raise RegimeSchemaError("regime_id_not_unique")
+
+    priorities = [regime.priority for regime in schema.regimes]
+    if len(set(priorities)) != len(priorities):
+        raise RegimeSchemaError("priority_not_unique")
+    if priorities != sorted(priorities, reverse=True):
+        raise RegimeSchemaError("priority_order_invalid")
+
+    if schema.regimes[0].regime_id != "RISK_OFF":
+        raise RegimeSchemaError("risk_off_not_first")
+    if schema.regimes[0].priority != max(priorities):
+        raise RegimeSchemaError("risk_off_not_highest_priority")
+
+    neutral = [regime for regime in schema.regimes if regime.regime_id == "NEUTRAL"]
+    if len(neutral) != 1:
+        raise RegimeSchemaError("neutral_missing")
+    if schema.regimes[-1].regime_id != "NEUTRAL":
+        raise RegimeSchemaError("neutral_not_last")
+    if neutral[0].conditions is not None:
+        raise RegimeSchemaError("neutral_conditions_not_allowed")
+    if neutral[0].priority != min(priorities):
+        raise RegimeSchemaError("neutral_not_lowest_priority")
+
+    for regime in schema.regimes:
+        if regime.regime_id != "NEUTRAL" and regime.conditions is None:
+            raise RegimeSchemaError(f"conditions_required:{regime.regime_id}")
+        _ensure_unique_list(regime.allowed_strategy_families, "allowed_strategy_families")
+        _ensure_unique_list(regime.forbidden_strategy_families, "forbidden_strategy_families")
+
+    feature_aliases, alias_to_canonical = _build_alias_maps(schema)
+    known_features = _known_feature_names()
+    referenced = _collect_referenced_features(schema)
+    for feature in referenced:
+        if feature in known_features:
+            continue
+        if feature in feature_aliases:
+            continue
+        if feature in alias_to_canonical:
+            continue
+        raise RegimeSchemaError(f"unknown_feature:{feature}")
+
+    regimes = tuple(
+        RegimeRule(
+            regime_id=regime.regime_id,
+            description=regime.description,
+            priority=regime.priority,
+            conditions=regime.conditions,
+            allowed_strategy_families=tuple(regime.allowed_strategy_families),
+            forbidden_strategy_families=tuple(regime.forbidden_strategy_families),
+            risk_modifiers=dict(regime.risk_modifiers),
+            rationale=tuple(regime.rationale),
+        )
+        for regime in schema.regimes
+    )
+
+    return RegimeConfig(
+        schema_version=schema.schema_version,
+        regimes=regimes,
+        required_features=frozenset(referenced),
+        feature_aliases=feature_aliases,
+        alias_to_canonical=alias_to_canonical,
+    )
+
+
+def _known_feature_names() -> set[str]:
+    outputs: set[str] = set()
+    for spec in FEATURES.values():
+        for out in spec["outputs"]:
+            outputs.add(out)
+    outputs.update({"atr_pct", "realized_vol", "realized_vol_20"})
+    return outputs
+
+
+def _collect_referenced_features(schema: RegimeSchema) -> set[str]:
+    features: set[str] = set()
+    for regime in schema.regimes:
+        if regime.conditions is None:
+            continue
+        for name in regime.conditions.iter_features():
+            features.add(name)
+    return features
+
+
+def _build_alias_maps(schema: RegimeSchema) -> tuple[dict[str, tuple[str, ...]], dict[str, str]]:
+    feature_aliases: dict[str, tuple[str, ...]] = {}
+    alias_to_canonical: dict[str, str] = {}
+    for entry in schema.feature_catalog:
+        if entry.name in feature_aliases or entry.name in alias_to_canonical:
+            raise RegimeSchemaError("feature_catalog_duplicate")
+        aliases = tuple(alias for alias in entry.aliases if alias)
+        feature_aliases[entry.name] = aliases
+        for alias in aliases:
+            if alias in alias_to_canonical or alias in feature_aliases:
+                raise RegimeSchemaError("feature_catalog_alias_duplicate")
+            alias_to_canonical[alias] = entry.name
+    return feature_aliases, alias_to_canonical
+
+
+def _ensure_unique_list(values: list[str], field_name: str) -> None:
+    if len(set(values)) != len(values):
+        raise RegimeSchemaError(f"{field_name}_not_unique")

--- a/src/buff/regimes/schema.py
+++ b/src/buff/regimes/schema.py
@@ -1,0 +1,108 @@
+"""Pydantic schema for regime rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class FeatureCatalogEntry(BaseModel):
+    name: str
+    aliases: list[str] = Field(default_factory=list)
+    description: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Condition(BaseModel):
+    op: str
+    items: list["Condition"] = Field(default_factory=list)
+    feature: str | None = None
+    value: float | None = None
+    lower: float | None = None
+    upper: float | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse(cls, value: Any) -> Any:
+        if not isinstance(value, dict) or len(value) != 1:
+            raise ValueError("condition_invalid")
+        op, payload = next(iter(value.items()))
+        if op in {"all", "any"}:
+            if not isinstance(payload, list) or not payload:
+                raise ValueError("condition_list_required")
+            return {"op": op, "items": payload}
+        if op == "not":
+            if not isinstance(payload, dict):
+                raise ValueError("condition_not_requires_object")
+            return {"op": op, "items": [payload]}
+        if op in {"gt", "gte", "lt", "lte", "abs_gt"}:
+            feature, numeric = _parse_feature_numeric(payload)
+            return {"op": op, "feature": feature, "value": numeric}
+        if op == "between":
+            feature, bounds = _parse_feature_bounds(payload)
+            return {"op": op, "feature": feature, "lower": bounds[0], "upper": bounds[1]}
+        raise ValueError(f"condition_operator_unknown:{op}")
+
+    def iter_features(self) -> list[str]:
+        if self.feature:
+            return [self.feature]
+        features: list[str] = []
+        for item in self.items:
+            features.extend(item.iter_features())
+        return features
+
+
+class RegimeDefinition(BaseModel):
+    regime_id: str
+    description: str
+    priority: int
+    conditions: Condition | None = None
+    allowed_strategy_families: list[str]
+    forbidden_strategy_families: list[str]
+    risk_modifiers: dict[str, Any] = Field(default_factory=dict)
+    rationale: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RegimeSchema(BaseModel):
+    schema_version: str
+    regimes: list[RegimeDefinition]
+    feature_catalog: list[FeatureCatalogEntry] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _parse_feature_numeric(payload: Any) -> tuple[str, float]:
+    if not isinstance(payload, dict) or len(payload) != 1:
+        raise ValueError("condition_numeric_invalid")
+    feature, numeric = next(iter(payload.items()))
+    if not isinstance(feature, str) or not feature:
+        raise ValueError("condition_feature_invalid")
+    if isinstance(numeric, bool) or not isinstance(numeric, (int, float)):
+        raise ValueError("condition_numeric_invalid")
+    return feature, float(numeric)
+
+
+def _parse_feature_bounds(payload: Any) -> tuple[str, tuple[float, float]]:
+    if not isinstance(payload, dict) or len(payload) != 1:
+        raise ValueError("condition_between_invalid")
+    feature, bounds = next(iter(payload.items()))
+    if not isinstance(feature, str) or not feature:
+        raise ValueError("condition_feature_invalid")
+    if not isinstance(bounds, (list, tuple)) or len(bounds) != 2:
+        raise ValueError("condition_between_bounds_invalid")
+    lower, upper = bounds[0], bounds[1]
+    if isinstance(lower, bool) or not isinstance(lower, (int, float)):
+        raise ValueError("condition_between_bounds_invalid")
+    if isinstance(upper, bool) or not isinstance(upper, (int, float)):
+        raise ValueError("condition_between_bounds_invalid")
+    lower_f = float(lower)
+    upper_f = float(upper)
+    if lower_f > upper_f:
+        raise ValueError("condition_between_bounds_invalid")
+    return feature, (lower_f, upper_f)

--- a/src/buff/regimes/types.py
+++ b/src/buff/regimes/types.py
@@ -1,0 +1,38 @@
+"""Types for regime semantics outputs and configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from buff.regimes.schema import Condition
+
+
+@dataclass(frozen=True)
+class RegimeRule:
+    regime_id: str
+    description: str
+    priority: int
+    conditions: Condition | None
+    allowed_strategy_families: tuple[str, ...]
+    forbidden_strategy_families: tuple[str, ...]
+    risk_modifiers: Mapping[str, Any]
+    rationale: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RegimeConfig:
+    schema_version: str
+    regimes: tuple[RegimeRule, ...]
+    required_features: frozenset[str]
+    feature_aliases: dict[str, tuple[str, ...]]
+    alias_to_canonical: dict[str, str]
+
+
+@dataclass(frozen=True)
+class RegimeDecision:
+    regime_id: str
+    matched_conditions_summary: str
+    allowed_strategy_families: tuple[str, ...]
+    forbidden_strategy_families: tuple[str, ...]
+    risk_modifiers: Mapping[str, Any]

--- a/tests/test_regime_integration_with_features.py
+++ b/tests/test_regime_integration_with_features.py
@@ -1,0 +1,33 @@
+"""Integration test using golden feature outputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from buff.regimes.evaluator import evaluate_regime
+from buff.regimes.parser import load_regime_config
+
+
+def test_regime_integration_with_features() -> None:
+    df = pd.read_csv(Path("tests/goldens/expected.csv"))
+    df["atr_pct"] = df["atr_14"] / df["close"]
+
+    close = df["close"].astype(float)
+    log_returns = np.log(close).diff()
+    df["realized_vol_20"] = log_returns.rolling(window=20, min_periods=20).std(ddof=0)
+
+    row = df.iloc[-1].to_dict()
+    config = load_regime_config(Path("knowledge/regimes.yaml"))
+    decision = evaluate_regime(row, config)
+    assert decision.regime_id in {
+        "RISK_OFF",
+        "HIGH_VOL_TREND",
+        "LOW_VOL_TREND",
+        "HIGH_VOL_RANGE",
+        "LOW_VOL_RANGE",
+        "MEAN_REVERSION_BIAS",
+        "NEUTRAL",
+    }

--- a/tests/unit/test_regime_classification_examples.py
+++ b/tests/unit/test_regime_classification_examples.py
@@ -1,0 +1,62 @@
+"""Explicit classification examples for each regime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from buff.regimes.evaluator import evaluate_regime
+from buff.regimes.parser import load_regime_config
+
+
+def _base_features() -> dict[str, float]:
+    return {
+        "adx_14": 22.0,
+        "atr_pct": 0.015,
+        "realized_vol_20": 0.02,
+        "rsi_14": 50.0,
+        "rsi_slope_14_5": 0.0,
+        "ema_spread_20_50": 0.0,
+        "vwap_typical_daily": 100.0,
+        "bb_upper_20_2": 101.0,
+        "bb_lower_20_2": 99.0,
+    }
+
+
+def test_regime_examples() -> None:
+    config = load_regime_config(Path("knowledge/regimes.yaml"))
+
+    risk_off = _base_features()
+    risk_off.update({"atr_pct": 0.04})
+    assert evaluate_regime(risk_off, config).regime_id == "RISK_OFF"
+
+    high_vol_trend = _base_features()
+    high_vol_trend.update({"adx_14": 30.0, "atr_pct": 0.021})
+    assert evaluate_regime(high_vol_trend, config).regime_id == "HIGH_VOL_TREND"
+
+    low_vol_trend = _base_features()
+    low_vol_trend.update({"adx_14": 30.0, "atr_pct": 0.008, "realized_vol_20": 0.012})
+    assert evaluate_regime(low_vol_trend, config).regime_id == "LOW_VOL_TREND"
+
+    high_vol_range = _base_features()
+    high_vol_range.update({"adx_14": 15.0, "atr_pct": 0.021})
+    assert evaluate_regime(high_vol_range, config).regime_id == "HIGH_VOL_RANGE"
+
+    low_vol_range = _base_features()
+    low_vol_range.update({"adx_14": 15.0, "atr_pct": 0.008, "realized_vol_20": 0.012})
+    assert evaluate_regime(low_vol_range, config).regime_id == "LOW_VOL_RANGE"
+
+    mean_reversion = _base_features()
+    mean_reversion.update(
+        {
+            "adx_14": 15.0,
+            "atr_pct": 0.012,
+            "realized_vol_20": 0.015,
+            "rsi_14": 75.0,
+            "rsi_slope_14_5": 0.5,
+            "ema_spread_20_50": 0.2,
+        }
+    )
+    assert evaluate_regime(mean_reversion, config).regime_id == "MEAN_REVERSION_BIAS"
+
+    neutral = _base_features()
+    assert evaluate_regime(neutral, config).regime_id == "NEUTRAL"

--- a/tests/unit/test_regime_evaluator_determinism.py
+++ b/tests/unit/test_regime_evaluator_determinism.py
@@ -1,0 +1,96 @@
+"""Evaluator determinism tests for regime semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from buff.regimes.evaluator import evaluate_regime
+from buff.regimes.parser import load_regime_config
+
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "regimes.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_evaluator_is_deterministic(tmp_path: Path) -> None:
+    payload = """
+    schema_version: "1"
+    regimes:
+      - regime_id: RISK_OFF
+        description: x
+        priority: 3
+        conditions:
+          any:
+            - gte: { atr_pct: 0.5 }
+        allowed_strategy_families: [do_not_trade]
+        forbidden_strategy_families: [trend_following]
+      - regime_id: FIRST
+        description: x
+        priority: 2
+        conditions:
+          any:
+            - gte: { atr_pct: 0.1 }
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+      - regime_id: SECOND
+        description: x
+        priority: 1
+        conditions:
+          any:
+            - gte: { atr_pct: 0.1 }
+        allowed_strategy_families: [breakout]
+        forbidden_strategy_families: [do_not_trade]
+      - regime_id: NEUTRAL
+        description: x
+        priority: 0
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+    """
+    path = _write_yaml(tmp_path, payload)
+    config = load_regime_config(path)
+    features = {"atr_pct": 0.2}
+    decision_a = evaluate_regime(features, config)
+    decision_b = evaluate_regime(features, config)
+    assert decision_a == decision_b
+
+
+def test_first_match_wins_by_priority(tmp_path: Path) -> None:
+    payload = """
+    schema_version: "1"
+    regimes:
+      - regime_id: RISK_OFF
+        description: x
+        priority: 3
+        conditions:
+          any:
+            - gte: { atr_pct: 0.5 }
+        allowed_strategy_families: [do_not_trade]
+        forbidden_strategy_families: [trend_following]
+      - regime_id: FIRST
+        description: x
+        priority: 2
+        conditions:
+          any:
+            - gte: { atr_pct: 0.1 }
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+      - regime_id: SECOND
+        description: x
+        priority: 1
+        conditions:
+          any:
+            - gte: { atr_pct: 0.1 }
+        allowed_strategy_families: [breakout]
+        forbidden_strategy_families: [do_not_trade]
+      - regime_id: NEUTRAL
+        description: x
+        priority: 0
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+    """
+    path = _write_yaml(tmp_path, payload)
+    config = load_regime_config(path)
+    decision = evaluate_regime({"atr_pct": 0.2}, config)
+    assert decision.regime_id == "FIRST"

--- a/tests/unit/test_regime_schema_validation.py
+++ b/tests/unit/test_regime_schema_validation.py
@@ -1,0 +1,100 @@
+"""Schema validation tests for regime semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from buff.regimes.evaluator import evaluate_regime
+from buff.regimes.errors import RegimeSchemaError
+from buff.regimes.parser import load_regime_config
+
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "regimes.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_unknown_feature_rejected(tmp_path: Path) -> None:
+    payload = """
+    schema_version: "1"
+    regimes:
+      - regime_id: RISK_OFF
+        description: x
+        priority: 2
+        conditions:
+          any:
+            - gte: { unknown_feature: 1.0 }
+        allowed_strategy_families: [do_not_trade]
+        forbidden_strategy_families: [trend_following]
+      - regime_id: NEUTRAL
+        description: x
+        priority: 0
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+    """
+    path = _write_yaml(tmp_path, payload)
+    with pytest.raises(RegimeSchemaError):
+        load_regime_config(path)
+
+
+def test_missing_priority_rejected(tmp_path: Path) -> None:
+    payload = """
+    schema_version: "1"
+    regimes:
+      - regime_id: RISK_OFF
+        description: x
+        conditions:
+          any:
+            - gte: { atr_pct: 0.02 }
+        allowed_strategy_families: [do_not_trade]
+        forbidden_strategy_families: [trend_following]
+      - regime_id: NEUTRAL
+        description: x
+        priority: 0
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+    """
+    path = _write_yaml(tmp_path, payload)
+    with pytest.raises(RegimeSchemaError):
+        load_regime_config(path)
+
+
+def test_neutral_must_be_lowest_priority(tmp_path: Path) -> None:
+    payload = """
+    schema_version: "1"
+    regimes:
+      - regime_id: RISK_OFF
+        description: x
+        priority: 3
+        conditions:
+          any:
+            - gte: { atr_pct: 0.02 }
+        allowed_strategy_families: [do_not_trade]
+        forbidden_strategy_families: [trend_following]
+      - regime_id: NEUTRAL
+        description: x
+        priority: 1
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+      - regime_id: OTHER
+        description: x
+        priority: 0
+        conditions:
+          any:
+            - gte: { atr_pct: 0.01 }
+        allowed_strategy_families: [trend_following]
+        forbidden_strategy_families: [do_not_trade]
+    """
+    path = _write_yaml(tmp_path, payload)
+    with pytest.raises(RegimeSchemaError):
+        load_regime_config(path)
+
+
+def test_missing_features_fail_closed() -> None:
+    config = load_regime_config(Path("knowledge/regimes.yaml"))
+    decision = evaluate_regime({"atr_pct": 0.005}, config)
+    assert decision.regime_id == "RISK_OFF"
+    assert "missing_features" in decision.matched_conditions_summary


### PR DESCRIPTION
DESCRIPTION:
Summary
- Added deterministic, rule-based regime semantics backed by a validated YAML knowledge base (knowledge/regimes.yaml).
- Introduced strategy-family permission mapping (allowed/forbidden) with fail-closed default to RISK_OFF on missing/invalid features.
- Implemented schema + parser + evaluator in src/buff/regimes/* with strict validation and deterministic matched-condition summaries.
- Added CLI command to classify regimes from OHLCV/features: `buff regimes classify`.
- Documented regime taxonomy, default thresholds, and safe extension rules in docs/REGIME_SEMANTICS.md.
- Added unit + integration tests covering schema validation, determinism, example classifications, and pipeline integration.

Verification
- ruff format: PASS
- ruff check: PASS
- pytest -q: 322 passed, 1 skipped

Notes
- No changes to indicator math or goldens in this PR.
- Regime thresholds were sanity-checked against real feature scales to avoid nonsensical comparisons.