### PR TITLE
M3: deterministic feature & regime engine + CLI artifact

### DIFF
--- a/src/features/build_features.py
+++ b/src/features/build_features.py
@@ -1,0 +1,144 @@
+"""Deterministic feature construction for M3 market state inputs."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from buff.features.indicators import adx_wilder, atr_wilder, ema, rsi_slope, rsi_wilder
+
+REQUIRED_COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+
+LOG_RETURN_WINDOWS = (1, 5, 20)
+VOLUME_ZSCORE_WINDOW = 20
+EMA_FAST = 20
+EMA_SLOW = 50
+RSI_PERIOD = 14
+RSI_SLOPE_PERIOD = 5
+ATR_PERIOD = 14
+REALIZED_VOL_WINDOW = 20
+ADX_PERIOD = 14
+FEATURE_COLUMNS = [
+    "log_return_1",
+    "log_return_5",
+    "log_return_20",
+    "volume_zscore_20",
+    "ema_20",
+    "ema_50",
+    "ema_spread_20_50_pct",
+    "rsi_14",
+    "rsi_slope_14_5",
+    "atr_14",
+    "atr_pct",
+    "realized_vol_20",
+    "adx_14",
+]
+
+
+def _ensure_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
+    missing = sorted(set(required) - set(df.columns))
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+
+def _normalize_timestamp(series: pd.Series) -> pd.Series:
+    if pd.api.types.is_numeric_dtype(series):
+        ts = pd.to_datetime(series, unit="ms", utc=True, errors="coerce")
+    else:
+        ts = pd.to_datetime(series, utc=True, errors="coerce")
+    if ts.isna().any():
+        raise ValueError("Invalid timestamp values")
+    return ts
+
+
+def _prepare_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+    _ensure_columns(df, REQUIRED_COLUMNS)
+    if df.empty:
+        empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"], dtype="float64")
+        empty.index = pd.DatetimeIndex([], name="timestamp")
+        return empty
+
+    data = df.copy()
+    data["timestamp"] = _normalize_timestamp(data["timestamp"])
+
+    if data["timestamp"].duplicated().any():
+        raise ValueError("Duplicate timestamps are not allowed")
+    if not data["timestamp"].is_monotonic_increasing:
+        raise ValueError("Timestamps must be monotonic increasing")
+
+    for col in ["open", "high", "low", "close", "volume"]:
+        numeric = pd.to_numeric(data[col], errors="coerce")
+        if numeric.isna().any():
+            raise ValueError(f"Non-numeric or NaN values found in '{col}'")
+        data[col] = numeric.astype("float64")
+
+    data = data.sort_values("timestamp")
+    data.index = data["timestamp"]
+    data.index.name = "timestamp"
+    return data.drop(columns=["timestamp"])
+
+
+def build_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute deterministic features using only past and current bars."""
+    ohlcv = _prepare_ohlcv(df)
+    if ohlcv.empty:
+        return pd.DataFrame(columns=FEATURE_COLUMNS, index=ohlcv.index)
+
+    close = ohlcv["close"]
+    high = ohlcv["high"]
+    low = ohlcv["low"]
+    volume = ohlcv["volume"]
+
+    # Past-only log returns via positive shifts.
+    log_return_1 = np.log(close / close.shift(LOG_RETURN_WINDOWS[0]))
+    log_return_5 = np.log(close / close.shift(LOG_RETURN_WINDOWS[1]))
+    log_return_20 = np.log(close / close.shift(LOG_RETURN_WINDOWS[2]))
+
+    # Rolling windows are explicitly past/current only (no centering).
+    vol_mean = volume.rolling(window=VOLUME_ZSCORE_WINDOW, min_periods=VOLUME_ZSCORE_WINDOW).mean()
+    vol_std = volume.rolling(window=VOLUME_ZSCORE_WINDOW, min_periods=VOLUME_ZSCORE_WINDOW).std(
+        ddof=0
+    )
+    volume_zscore_20 = (volume - vol_mean) / vol_std.replace(0.0, np.nan)
+
+    ema_20 = ema(close, period=EMA_FAST)
+    ema_50 = ema(close, period=EMA_SLOW)
+    ema_spread_20_50_pct = (ema_20 - ema_50) / ema_50.replace(0.0, np.nan)
+
+    rsi_14 = rsi_wilder(close, period=RSI_PERIOD)
+    rsi_slope_14_5 = rsi_slope(close, period=RSI_PERIOD, slope=RSI_SLOPE_PERIOD)
+
+    atr_14 = atr_wilder(high, low, close, period=ATR_PERIOD)
+    atr_pct = atr_14 / close.replace(0.0, np.nan)
+
+    # Realized volatility uses a fixed past window of log returns.
+    realized_vol_20 = log_return_1.rolling(
+        window=REALIZED_VOL_WINDOW, min_periods=REALIZED_VOL_WINDOW
+    ).std(ddof=0)
+
+    adx_14_frame = adx_wilder(high, low, close, period=ADX_PERIOD)
+    adx_14 = adx_14_frame["adx"]
+
+    out = pd.DataFrame(
+        {
+            "log_return_1": log_return_1,
+            "log_return_5": log_return_5,
+            "log_return_20": log_return_20,
+            "volume_zscore_20": volume_zscore_20,
+            "ema_20": ema_20,
+            "ema_50": ema_50,
+            "ema_spread_20_50_pct": ema_spread_20_50_pct,
+            "rsi_14": rsi_14,
+            "rsi_slope_14_5": rsi_slope_14_5,
+            "atr_14": atr_14,
+            "atr_pct": atr_pct,
+            "realized_vol_20": realized_vol_20,
+            "adx_14": adx_14,
+        },
+        index=ohlcv.index,
+    )
+    out = out[FEATURE_COLUMNS]
+    out.index.name = "timestamp"
+    return out

--- a/src/features/cli.py
+++ b/src/features/cli.py
@@ -1,0 +1,60 @@
+"""Standalone CLI for M3 feature/regime artifact generation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from .build_features import FEATURE_COLUMNS, build_features
+from .regime import REGIME_COLUMNS, build_market_state, write_market_state
+
+
+def _coerce_output(frame: pd.DataFrame) -> pd.DataFrame:
+    ordered = FEATURE_COLUMNS + REGIME_COLUMNS
+    if "volatility_cluster" in frame.columns:
+        ordered.append("volatility_cluster")
+    missing = [col for col in ordered if col not in frame.columns]
+    if missing:
+        raise ValueError(f"Missing expected output columns: {missing}")
+
+    out = frame[ordered].copy()
+    for col in FEATURE_COLUMNS:
+        out[col] = pd.to_numeric(out[col], errors="coerce").astype("float64")
+    for col in REGIME_COLUMNS:
+        out[col] = out[col].astype("string")
+    if "volatility_cluster" in out.columns:
+        out["volatility_cluster"] = out["volatility_cluster"].astype("string")
+    return out
+
+
+def _parse_args(argv: Iterable[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build deterministic market_state features.")
+    parser.add_argument("--input", dest="input_path", required=True, help="OHLCV parquet input.")
+    parser.add_argument(
+        "--output",
+        dest="output_path",
+        default="features/market_state.parquet",
+        help="Output parquet path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv)
+    input_path = Path(args.input_path)
+    output_path = Path(args.output_path)
+
+    ohlcv = pd.read_parquet(input_path)
+    features = build_features(ohlcv)
+    market_state = build_market_state(features)
+    market_state = _coerce_output(market_state)
+
+    write_market_state(market_state, out_path=output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/regime.py
+++ b/src/features/regime.py
@@ -1,0 +1,180 @@
+"""Deterministic market regime labels derived from feature inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .build_features import FEATURE_COLUMNS
+
+EMA_SPREAD_THRESHOLD = 0.001
+RSI_BULL = 55.0
+RSI_BEAR = 45.0
+RSI_SLOPE_THRESHOLD = 0.1
+
+ATR_PCT_LOW_QUANTILE = 0.33
+ATR_PCT_HIGH_QUANTILE = 0.67
+
+KMEANS_RANDOM_SEED = 7
+KMEANS_CLUSTERS = 3
+
+OUTPUT_PATH = Path("features/market_state.parquet")
+PARQUET_COMPRESSION = "zstd"
+PARQUET_COMPRESSION_LEVEL = 3
+PARQUET_ROW_GROUP_SIZE = 100_000
+PARQUET_DATA_PAGE_SIZE = 1_048_576
+PARQUET_WRITE_STATISTICS = False
+
+REGIME_COLUMNS = ["trend_state", "momentum_state", "volatility_regime"]
+
+
+def _ensure_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
+    missing = sorted(set(required) - set(df.columns))
+    if missing:
+        raise ValueError(f"Missing required feature columns: {missing}")
+
+
+def _volatility_cluster(
+    atr_pct: pd.Series,
+    *,
+    n_clusters: int = KMEANS_CLUSTERS,
+    seed: int = KMEANS_RANDOM_SEED,
+) -> pd.Series | None:
+    try:
+        from sklearn.cluster import KMeans  # type: ignore
+    except Exception:
+        return None
+
+    values = atr_pct.dropna().to_numpy().reshape(-1, 1)
+    if values.shape[0] < n_clusters:
+        return None
+
+    kmeans = KMeans(n_clusters=n_clusters, random_state=seed, n_init=10)
+    labels = kmeans.fit_predict(values)
+
+    centers = kmeans.cluster_centers_.reshape(-1)
+    order = np.argsort(centers)
+    if n_clusters == 3:
+        names = ("low", "mid", "high")
+    else:
+        names = tuple(f"cluster_{i}" for i in range(n_clusters))
+    label_map = {int(order[i]): names[i] for i in range(n_clusters)}
+
+    cluster = pd.Series(index=atr_pct.index, dtype="string")
+    cluster.loc[atr_pct.dropna().index] = [label_map[int(label)] for label in labels]
+    return cluster
+
+
+def classify_regimes(
+    features: pd.DataFrame,
+    *,
+    ema_spread_threshold: float = EMA_SPREAD_THRESHOLD,
+    rsi_bull: float = RSI_BULL,
+    rsi_bear: float = RSI_BEAR,
+    rsi_slope_threshold: float = RSI_SLOPE_THRESHOLD,
+    atr_pct_low_quantile: float = ATR_PCT_LOW_QUANTILE,
+    atr_pct_high_quantile: float = ATR_PCT_HIGH_QUANTILE,
+    include_volatility_cluster: bool = False,
+) -> pd.DataFrame:
+    """Classify deterministic regimes from precomputed features."""
+    required = {"ema_20", "ema_50", "rsi_14", "rsi_slope_14_5", "atr_pct"}
+    _ensure_columns(features, required)
+
+    spread = features.get("ema_spread_20_50_pct")
+    if spread is None:
+        denom = features["ema_50"].replace(0.0, np.nan)
+        spread = (features["ema_20"] - features["ema_50"]) / denom
+
+    trend_state = pd.Series("flat", index=features.index, dtype="string")
+    trend_state = trend_state.mask(spread > ema_spread_threshold, "up")
+    trend_state = trend_state.mask(spread < -ema_spread_threshold, "down")
+
+    rsi = features["rsi_14"].astype(float)
+    rsi_slope_val = features["rsi_slope_14_5"].astype(float)
+
+    momentum_state = pd.Series("neutral", index=features.index, dtype="string")
+    bull_mask = (rsi >= rsi_bull) & (rsi_slope_val >= rsi_slope_threshold)
+    bear_mask = (rsi <= rsi_bear) & (rsi_slope_val <= -rsi_slope_threshold)
+    momentum_state = momentum_state.mask(bull_mask, "bull")
+    momentum_state = momentum_state.mask(bear_mask, "bear")
+
+    atr_pct = features["atr_pct"].astype(float)
+    valid = atr_pct.dropna()
+    volatility_regime = pd.Series("normal", index=features.index, dtype="string")
+
+    if not valid.empty:
+        low_cut = float(np.nanpercentile(valid, atr_pct_low_quantile * 100.0))
+        high_cut = float(np.nanpercentile(valid, atr_pct_high_quantile * 100.0))
+        if np.isfinite(low_cut) and np.isfinite(high_cut) and low_cut < high_cut:
+            volatility_regime = volatility_regime.mask(atr_pct <= low_cut, "low")
+            volatility_regime = volatility_regime.mask(atr_pct >= high_cut, "high")
+
+    out = pd.DataFrame(
+        {
+            "trend_state": trend_state,
+            "momentum_state": momentum_state,
+            "volatility_regime": volatility_regime,
+        },
+        index=features.index,
+    )
+
+    if include_volatility_cluster:
+        cluster = _volatility_cluster(atr_pct)
+        if cluster is not None:
+            out["volatility_cluster"] = cluster
+
+    ordered = REGIME_COLUMNS + ([col for col in out.columns if col not in REGIME_COLUMNS])
+    return out[ordered]
+
+
+def build_market_state(
+    features: pd.DataFrame,
+    *,
+    include_volatility_cluster: bool = False,
+) -> pd.DataFrame:
+    """Combine features with regime labels for storage or analysis."""
+    regimes = classify_regimes(
+        features,
+        include_volatility_cluster=include_volatility_cluster,
+    )
+    combined = pd.concat([features, regimes], axis=1)
+    ordered = FEATURE_COLUMNS + REGIME_COLUMNS
+    if "volatility_cluster" in combined.columns:
+        ordered.append("volatility_cluster")
+    combined = combined[ordered]
+    combined.index.name = features.index.name or "timestamp"
+    return combined
+
+
+def write_market_state(market_state: pd.DataFrame, out_path: Path = OUTPUT_PATH) -> Path:
+    """Persist market state features with deterministic Parquet settings."""
+    if market_state.empty:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        empty = market_state.copy()
+        if empty.index.name is None:
+            empty.index.name = "timestamp"
+        frame = empty.reset_index()
+    else:
+        ordered = market_state.sort_index()
+        ordered.index.name = ordered.index.name or "timestamp"
+        frame = ordered.reset_index()
+
+    table = pa.Table.from_pandas(frame, preserve_index=False)
+    table = table.replace_schema_metadata(None)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        table,
+        out_path,
+        compression=PARQUET_COMPRESSION,
+        compression_level=PARQUET_COMPRESSION_LEVEL,
+        use_dictionary=False,
+        row_group_size=PARQUET_ROW_GROUP_SIZE,
+        data_page_size=PARQUET_DATA_PAGE_SIZE,
+        write_statistics=PARQUET_WRITE_STATISTICS,
+    )
+    return out_path

--- a/tests/fixtures/ohlcv_factory.py
+++ b/tests/fixtures/ohlcv_factory.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def make_ohlcv(rows: int = 200, start: str = "2024-01-01T00:00:00Z") -> pd.DataFrame:
+    base = pd.Timestamp(start)
+    idx = np.arange(rows, dtype=float)
+    timestamps = [int((base + pd.Timedelta(hours=i)).timestamp() * 1000) for i in range(rows)]
+
+    trend = 0.05 * idx
+    seasonal = 2.0 * np.sin(idx / 12.0)
+    close = 100.0 + trend + seasonal
+    open_ = close + 0.1 * np.cos(idx / 8.0)
+    high = np.maximum(open_, close) + 0.5
+    low = np.minimum(open_, close) - 0.5
+    volume = 1000.0 + 25.0 * (idx % 5)
+
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        }
+    )

--- a/tests/test_features_cli_integration.py
+++ b/tests/test_features_cli_integration.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from features.build_features import FEATURE_COLUMNS
+from features.cli import main
+from features.regime import REGIME_COLUMNS
+from tests.fixtures.ohlcv_factory import make_ohlcv
+
+FORBIDDEN_TERMS = [
+    "signal",
+    "side",
+    "position",
+    "long",
+    "short",
+    "entry",
+    "exit",
+    "buy",
+    "sell",
+    "strategy_id",
+]
+
+
+def test_features_cli_integration(tmp_path: Path) -> None:
+    df = make_ohlcv(160)
+    input_path = tmp_path / "ohlcv.parquet"
+    output_a = tmp_path / "market_state_a.parquet"
+    output_b = tmp_path / "market_state_b.parquet"
+
+    df.to_parquet(input_path, index=False)
+    assert main(["--input", str(input_path), "--output", str(output_a)]) == 0
+    assert main(["--input", str(input_path), "--output", str(output_b)]) == 0
+
+    out_a = pd.read_parquet(output_a)
+    out_b = pd.read_parquet(output_b)
+    expected = ["timestamp"] + FEATURE_COLUMNS + REGIME_COLUMNS
+    assert list(out_a.columns) == expected
+    assert list(out_b.columns) == expected
+    assert out_a["timestamp"].is_monotonic_increasing
+    assert not out_a["timestamp"].duplicated().any()
+
+    lower_cols = [col.lower() for col in out_a.columns]
+    for term in FORBIDDEN_TERMS:
+        assert all(term not in col for col in lower_cols)
+
+    hash_a = pd.util.hash_pandas_object(out_a, index=False).values.tobytes()
+    hash_b = pd.util.hash_pandas_object(out_b, index=False).values.tobytes()
+    assert hash_a == hash_b

--- a/tests/test_features_reproducible.py
+++ b/tests/test_features_reproducible.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pandas as pd
+
+from features.build_features import build_features
+from features.regime import build_market_state, write_market_state
+from tests.fixtures.ohlcv_factory import make_ohlcv
+
+
+def _hash_frame(frame: pd.DataFrame) -> str:
+    digest = hashlib.sha256()
+    digest.update(pd.util.hash_pandas_object(frame, index=True).values.tobytes())
+    return digest.hexdigest()
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def test_features_reproducible(tmp_path: Path) -> None:
+    df = make_ohlcv(240)
+    out_a = build_market_state(build_features(df))
+    out_b = build_market_state(build_features(df))
+    assert _hash_frame(out_a) == _hash_frame(out_b)
+
+    path_a = write_market_state(out_a, tmp_path / "a.parquet")
+    path_b = write_market_state(out_b, tmp_path / "b.parquet")
+    assert _hash_file(path_a) == _hash_file(path_b)

--- a/tests/test_m3_feature_invariants.py
+++ b/tests/test_m3_feature_invariants.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from features.build_features import build_features
+from features.regime import build_market_state
+from tests.fixtures.ohlcv_factory import make_ohlcv
+
+FORBIDDEN_TERMS = [
+    "signal",
+    "side",
+    "position",
+    "long",
+    "short",
+    "entry",
+    "exit",
+    "buy",
+    "sell",
+    "strategy_id",
+]
+
+REQUIRED_COLUMNS = [
+    "log_return_1",
+    "log_return_5",
+    "log_return_20",
+    "volume_zscore_20",
+    "ema_20",
+    "ema_50",
+    "ema_spread_20_50_pct",
+    "rsi_14",
+    "rsi_slope_14_5",
+    "atr_14",
+    "atr_pct",
+    "realized_vol_20",
+    "adx_14",
+    "trend_state",
+    "momentum_state",
+    "volatility_regime",
+]
+
+
+def _scan_feature_sources() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    feature_dir = repo_root / "src" / "features"
+    for path in sorted(feature_dir.rglob("*.py")):
+        text = path.read_text(encoding="utf-8").lower()
+        for term in FORBIDDEN_TERMS:
+            assert term not in text, f"Forbidden term '{term}' found in {path}"
+
+
+def test_no_trading_terms_in_outputs_or_sources() -> None:
+    df = make_ohlcv(200)
+    market_state = build_market_state(build_features(df))
+
+    columns_lower = [col.lower() for col in market_state.columns]
+    for term in FORBIDDEN_TERMS:
+        assert all(term not in col for col in columns_lower), f"Forbidden term '{term}' in columns"
+
+    _scan_feature_sources()
+
+
+def test_feature_invariants() -> None:
+    df = make_ohlcv(240)
+    market_state = build_market_state(build_features(df))
+
+    assert market_state.index.is_monotonic_increasing
+    assert not market_state.index.has_duplicates
+
+    for col in REQUIRED_COLUMNS:
+        assert col in market_state.columns
+
+    allowed_trend = {"down", "flat", "up"}
+    allowed_momentum = {"bear", "neutral", "bull"}
+    allowed_volatility = {"low", "normal", "high"}
+
+    trend_vals = set(market_state["trend_state"].dropna().unique())
+    momentum_vals = set(market_state["momentum_state"].dropna().unique())
+    volatility_vals = set(market_state["volatility_regime"].dropna().unique())
+
+    assert trend_vals <= allowed_trend
+    assert momentum_vals <= allowed_momentum
+    assert volatility_vals <= allowed_volatility

--- a/tests/test_no_leakage.py
+++ b/tests/test_no_leakage.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from features.build_features import build_features
+from tests.fixtures.ohlcv_factory import make_ohlcv
+
+
+def _perturb_future(df: pd.DataFrame, cutoff_ms: int, seed: int) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    mutated = df.copy()
+    mask = mutated["timestamp"] > cutoff_ms
+    count = int(mask.sum())
+    if count == 0:
+        return mutated
+
+    base = rng.normal(100.0, 5.0, size=count)
+    open_ = base + rng.normal(0.0, 0.5, size=count)
+    close = base + rng.normal(0.0, 0.5, size=count)
+    high = np.maximum(open_, close) + rng.uniform(0.1, 1.5, size=count)
+    low = np.minimum(open_, close) - rng.uniform(0.1, 1.5, size=count)
+    volume = rng.uniform(500.0, 2000.0, size=count)
+
+    mutated.loc[mask, "open"] = open_
+    mutated.loc[mask, "high"] = high
+    mutated.loc[mask, "low"] = low
+    mutated.loc[mask, "close"] = close
+    mutated.loc[mask, "volume"] = volume
+    return mutated
+
+
+def _assert_no_future_leakage(df: pd.DataFrame, cutoff_ms: int, seed: int) -> None:
+    baseline = build_features(df)
+    mutated = _perturb_future(df, cutoff_ms, seed)
+    changed = build_features(mutated)
+
+    cutoff_ts = pd.to_datetime(cutoff_ms, unit="ms", utc=True)
+    pd.testing.assert_frame_equal(
+        baseline.loc[:cutoff_ts],
+        changed.loc[:cutoff_ts],
+        check_exact=True,
+    )
+
+
+def test_no_leakage_future_perturbation() -> None:
+    df = make_ohlcv(240)
+    cutoff_mid = int(df["timestamp"].iloc[len(df) // 2])
+    cutoff_near_end = int(df["timestamp"].iloc[-10])
+
+    _assert_no_future_leakage(df, cutoff_mid, seed=123)
+    _assert_no_future_leakage(df, cutoff_near_end, seed=456)

--- a/tests/test_regime_stability.py
+++ b/tests/test_regime_stability.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+
+from features.build_features import build_features
+from features.regime import classify_regimes
+from tests.fixtures.ohlcv_factory import make_ohlcv
+
+
+def test_regime_stability() -> None:
+    df = make_ohlcv(260)
+    base_features = build_features(df)
+    base = classify_regimes(base_features)
+
+    rng = np.random.default_rng(42)
+    noise = rng.normal(0.0, 0.001, size=len(df))
+
+    noisy = df.copy()
+    scale = 1.0 + noise
+    noisy["open"] = noisy["open"] * scale
+    noisy["high"] = noisy["high"] * scale
+    noisy["low"] = noisy["low"] * scale
+    noisy["close"] = noisy["close"] * scale
+
+    noisy_features = build_features(noisy)
+    noisy_regimes = classify_regimes(noisy_features)
+
+    warmup = 60
+    base_slice = base.iloc[warmup:]
+    noisy_slice = noisy_regimes.iloc[warmup:]
+
+    for col in ["trend_state", "momentum_state", "volatility_regime"]:
+        match_ratio = (base_slice[col] == noisy_slice[col]).mean()
+        assert match_ratio >= 0.7


### PR DESCRIPTION
## Summary
- Added deterministic M3 feature generation and regime labeling.
- Added standalone CLI to emit eatures/market_state.parquet.
- Added M3 tests for determinism, leakage resistance, invariants, and CLI integration.

## Proof (quality gates)
- ruff format: 247 files left unchanged
- ruff check: All checks passed!
- pytest: 338 passed, 1 skipped

## CLI usage
python -m src.features.cli --input <ohlcv.parquet> --output features/market_state.parquet

## Compliance
No trading logic / no decisions in M3.