### PR TITLE
chore: upgrade CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Summary:
- Upgrade CodeQL GitHub Action steps from v3 to v4 to address the Dec 2026 deprecation warning.
- No application code changes.

Notes:
- Same languages/triggers/permissions retained; only action versions updated.
