### PR TITLE
runtime: close S2 determinism gaps (float defense, precedence, digest-first verify)

### DIFF
--- a/src/s2/artifacts.py
+++ b/src/s2/artifacts.py
@@ -1351,7 +1351,7 @@ def run_s2_artifact_pack(request: S2ArtifactRequest, output_root: Path) -> Path:
         validate_s2_artifact_pack(run_dir)
         return run_dir
     except S2CoreError as exc:
-        failure_code = resolve_error_code([_error_code_from_core_error(exc), "SIMULATION_FAILED"])
+        failure_code = resolve_error_code([_error_code_from_core_error(exc)])
         failure_context = _build_failure_context(
             code=failure_code,
             exc=exc,

--- a/src/s2/artifacts.py
+++ b/src/s2/artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass, field
+from decimal import Decimal
 import json
 from pathlib import Path
 import re
@@ -40,6 +41,7 @@ from .failure import (
     S2StructuredFailure,
     build_run_failure_payload,
     deterministic_failure_timestamp,
+    resolve_error_code,
 )
 from .models import FundingDataMissingError, PositionInvariantError
 
@@ -591,6 +593,29 @@ def _assert_normalized_timestamps(value: Any, *, artifact: str) -> None:
     _walk(value)
 
 
+def _assert_no_float_tokens(value: Any, *, artifact: str, path: str = "$") -> None:
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, int):
+        return
+    if isinstance(value, (str, Decimal)):
+        return
+    if isinstance(value, float):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact contains non-canonical float token",
+            {"artifact": artifact, "path": path},
+        )
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _assert_no_float_tokens(child, artifact=artifact, path=f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for idx, child in enumerate(value):
+            _assert_no_float_tokens(child, artifact=artifact, path=f"{path}[{idx}]")
+        return
+
+
 def _read_artifact_bytes(path: Path) -> bytes:
     try:
         return path.read_bytes()
@@ -665,8 +690,8 @@ def _validate_artifact_pack_manifest(
     root: Path,
     payload: Mapping[str, Any],
     *,
-    expected_hash_scope: tuple[str, ...],
-    expected_run_status: str,
+    expected_hash_scope: tuple[str, ...] | None = None,
+    expected_run_status: str | None = None,
 ) -> dict[str, str]:
     if payload.get("schema_version") != ARTIFACT_PACK_MANIFEST_SCHEMA:
         raise S2ArtifactError(
@@ -691,7 +716,14 @@ def _validate_artifact_pack_manifest(
             "artifact pack numeric_policy mismatch",
             {"artifact": "artifact_pack_manifest.json"},
         )
-    if payload.get("run_status") != expected_run_status:
+    run_status = str(payload.get("run_status") or "")
+    if run_status not in {RUN_STATUS_SUCCEEDED, RUN_STATUS_FAILED}:
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack run_status invalid",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+    if expected_run_status is not None and run_status != expected_run_status:
         raise S2ArtifactError(
             "SCHEMA_INVALID",
             "artifact pack run_status mismatch",
@@ -723,7 +755,7 @@ def _validate_artifact_pack_manifest(
         path = str(row.get("path") or "")
         sha = str(row.get("sha256") or "")
         size_bytes = row.get("size_bytes")
-        if path not in expected_hash_scope:
+        if expected_hash_scope is not None and path not in expected_hash_scope:
             raise S2ArtifactError(
                 "SCHEMA_INVALID",
                 "artifact pack includes unsupported file path",
@@ -756,8 +788,48 @@ def _validate_artifact_pack_manifest(
             {"artifact": "artifact_pack_manifest.json"},
         )
 
-    manifest_paths = {row["path"] for row in parsed_entries}
-    expected_paths = set(expected_hash_scope)
+    hash_scope = payload.get("hash_scope")
+    if not isinstance(hash_scope, dict):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack hash_scope invalid",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+    included_files = hash_scope.get("included_files")
+    excluded_files = hash_scope.get("excluded_files")
+    if not isinstance(included_files, list) or not all(
+        isinstance(item, str) for item in included_files
+    ):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack hash_scope included_files invalid",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+    if not isinstance(excluded_files, list) or not all(
+        isinstance(item, str) for item in excluded_files
+    ):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack hash_scope excluded_files invalid",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+    if sorted(excluded_files) != sorted(PACK_HASH_EXCLUDED_ARTIFACTS):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack hash_scope excluded_files mismatch",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+
+    parsed_paths = tuple(row["path"] for row in parsed_entries)
+    if tuple(included_files) != parsed_paths:
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "artifact pack hash_scope included_files mismatch",
+            {"artifact": "artifact_pack_manifest.json"},
+        )
+
+    manifest_paths = set(parsed_paths)
+    expected_paths = set(expected_hash_scope if expected_hash_scope is not None else parsed_paths)
     if manifest_paths != expected_paths:
         raise S2ArtifactError(
             "SCHEMA_INVALID",
@@ -769,12 +841,20 @@ def _validate_artifact_pack_manifest(
             },
         )
 
-    actual_entries = _collect_file_entries(root, expected_hash_scope)
+    actual_entries = _collect_file_entries(root, parsed_paths)
     if parsed_entries != actual_entries:
+        mismatch_path = None
+        for expected_row, actual_row in zip(parsed_entries, actual_entries, strict=True):
+            if expected_row != actual_row:
+                mismatch_path = expected_row["path"]
+                break
         raise S2ArtifactError(
             "DIGEST_MISMATCH",
             "artifact pack file hashes mismatch",
-            {"artifact": "artifact_pack_manifest.json"},
+            {
+                "artifact": "artifact_pack_manifest.json",
+                "path": mismatch_path,
+            },
         )
     actual_root = build_pack_root_hash(actual_entries)
     if actual_root != root_hash:
@@ -795,9 +875,9 @@ def _validate_run_digests(
     payload: Mapping[str, Any],
     *,
     pack_file_hashes: Mapping[str, str],
-    manifest_replay_digest: str,
+    manifest_replay_digest: str | None = None,
     pack_root_hash: str,
-    expected_artifacts: tuple[str, ...],
+    expected_artifacts: tuple[str, ...] | None = None,
 ) -> dict[str, str]:
     if payload.get("schema_version") != RUN_DIGESTS_SCHEMA:
         raise S2ArtifactError(
@@ -826,8 +906,10 @@ def _validate_run_digests(
             {"artifact": "run_digests.json"},
         )
 
-    expected_digest_keys = sorted(name for name in expected_artifacts if name != "run_digests.json")
-    if sorted(digest_map.keys()) != expected_digest_keys:
+    expected_digest_keys = sorted(
+        name for name in expected_artifacts or () if name != "run_digests.json"
+    )
+    if expected_artifacts is not None and sorted(digest_map.keys()) != expected_digest_keys:
         raise S2ArtifactError(
             "DIGEST_MISMATCH",
             "run_digests artifact_sha256 keys mismatch",
@@ -837,6 +919,8 @@ def _validate_run_digests(
                 "actual_keys": sorted(digest_map.keys()),
             },
         )
+    if expected_artifacts is None:
+        expected_digest_keys = sorted(str(key) for key in digest_map.keys())
 
     for artifact_name in expected_digest_keys:
         actual_sha = sha256_hex_file(root / artifact_name)
@@ -885,7 +969,7 @@ def _validate_run_digests(
         )
 
     replay_digest = str(payload.get("replay_identity_digest_sha256") or "")
-    if replay_digest != manifest_replay_digest:
+    if manifest_replay_digest is not None and replay_digest != manifest_replay_digest:
         raise S2ArtifactError(
             "DIGEST_MISMATCH",
             "replay identity digest mismatch",
@@ -1267,7 +1351,7 @@ def run_s2_artifact_pack(request: S2ArtifactRequest, output_root: Path) -> Path:
         validate_s2_artifact_pack(run_dir)
         return run_dir
     except S2CoreError as exc:
-        failure_code = _error_code_from_core_error(exc)
+        failure_code = resolve_error_code([_error_code_from_core_error(exc), "SIMULATION_FAILED"])
         failure_context = _build_failure_context(
             code=failure_code,
             exc=exc,
@@ -1303,7 +1387,7 @@ def run_s2_artifact_pack(request: S2ArtifactRequest, output_root: Path) -> Path:
         )
         raise S2ArtifactError(failure_code, "core loop failed", {"error": str(exc)}) from exc
     except S2ArtifactError as exc:
-        failure_code = _error_code_from_artifact_error(exc)
+        failure_code = resolve_error_code([_error_code_from_artifact_error(exc), str(exc.code)])
         failure_context = _build_failure_context(
             code=failure_code,
             exc=exc,
@@ -1432,14 +1516,44 @@ def validate_s2_artifact_pack(run_dir: Path) -> dict[str, Any]:
     if not root.exists() or not root.is_dir():
         raise S2ArtifactError("ARTIFACT_MISSING", "run directory missing", {"run_dir": str(root)})
 
-    manifest_path = root / "paper_run_manifest.json"
-    if not manifest_path.exists() or not manifest_path.is_file():
-        raise S2ArtifactError(
-            "ARTIFACT_MISSING", "required artifact missing", {"artifact": "paper_run_manifest.json"}
-        )
-    _validate_artifact_encoding(root, "paper_run_manifest.json")
+    bootstrap_artifacts = (
+        "paper_run_manifest.json",
+        "artifact_pack_manifest.json",
+        "run_digests.json",
+    )
+    for name in bootstrap_artifacts:
+        artifact = root / name
+        if not artifact.exists():
+            raise S2ArtifactError(
+                "ARTIFACT_MISSING", "required artifact missing", {"artifact": name}
+            )
+        if not artifact.is_file():
+            raise S2ArtifactError(
+                "ARTIFACT_MISSING", "required artifact invalid", {"artifact": name}
+            )
+        _validate_artifact_encoding(root, name)
 
+    pack_manifest = _load_json(root / "artifact_pack_manifest.json")
+    _assert_no_float_tokens(pack_manifest, artifact="artifact_pack_manifest.json")
+    _assert_no_forbidden_paths(pack_manifest, artifact="artifact_pack_manifest.json")
+    _assert_normalized_timestamps(pack_manifest, artifact="artifact_pack_manifest.json")
+    pack_file_hashes = _validate_artifact_pack_manifest(root, pack_manifest)
+    pack_root_hash = str(pack_manifest["root_hash"])
+
+    run_digests = _load_json(root / "run_digests.json")
+    _assert_no_float_tokens(run_digests, artifact="run_digests.json")
+    _assert_no_forbidden_paths(run_digests, artifact="run_digests.json")
+    _assert_normalized_timestamps(run_digests, artifact="run_digests.json")
+    _validate_run_digests(
+        root,
+        run_digests,
+        pack_file_hashes=pack_file_hashes,
+        pack_root_hash=pack_root_hash,
+    )
+
+    manifest_path = root / "paper_run_manifest.json"
     manifest = _load_json(manifest_path)
+    _assert_no_float_tokens(manifest, artifact="paper_run_manifest.json")
     _validate_manifest_schema(manifest)
     _assert_no_forbidden_paths(manifest, artifact="paper_run_manifest.json")
     _assert_normalized_timestamps(manifest, artifact="paper_run_manifest.json")
@@ -1471,6 +1585,30 @@ def validate_s2_artifact_pack(run_dir: Path) -> dict[str, Any]:
             )
         _validate_artifact_encoding(root, name)
 
+    _validate_artifact_pack_manifest(
+        root,
+        pack_manifest,
+        expected_hash_scope=_pack_hash_scope_from_artifacts(expected_artifacts),
+        expected_run_status=run_status,
+    )
+
+    replay_identity = manifest.get("replay_identity")
+    if not isinstance(replay_identity, dict):
+        raise S2ArtifactError(
+            "SCHEMA_INVALID",
+            "manifest replay_identity invalid",
+            {"artifact": "paper_run_manifest.json"},
+        )
+    replay_digest = str(replay_identity.get("digest_sha256") or "")
+    digest_map = _validate_run_digests(
+        root,
+        run_digests,
+        pack_file_hashes=pack_file_hashes,
+        manifest_replay_digest=replay_digest,
+        pack_root_hash=pack_root_hash,
+        expected_artifacts=expected_artifacts,
+    )
+
     if run_status == RUN_STATUS_SUCCEEDED:
         if (root / "run_failure.json").exists():
             raise S2ArtifactError(
@@ -1481,12 +1619,14 @@ def validate_s2_artifact_pack(run_dir: Path) -> dict[str, Any]:
         for jsonl_name in JSONL_ARTIFACTS:
             path = root / jsonl_name
             rows = _load_jsonl(path)
+            _assert_no_float_tokens(rows, artifact=jsonl_name)
             _validate_jsonl_schema(path, rows)
             _validate_ordering(path, rows)
             _assert_no_forbidden_paths(rows, artifact=jsonl_name)
             _assert_normalized_timestamps(rows, artifact=jsonl_name)
 
         costs = _load_json(root / "cost_breakdown.json")
+        _assert_no_float_tokens(costs, artifact="cost_breakdown.json")
         if costs.get("schema_version") != COST_BREAKDOWN_SCHEMA:
             raise S2ArtifactError(
                 "SCHEMA_INVALID",
@@ -1527,45 +1667,16 @@ def validate_s2_artifact_pack(run_dir: Path) -> dict[str, Any]:
                     {"artifact": name},
                 )
         risk_rows = _load_jsonl(root / "risk_events.jsonl")
+        _assert_no_float_tokens(risk_rows, artifact="risk_events.jsonl")
         _validate_jsonl_schema(root / "risk_events.jsonl", risk_rows)
         _validate_ordering(root / "risk_events.jsonl", risk_rows)
         _assert_no_forbidden_paths(risk_rows, artifact="risk_events.jsonl")
         _assert_normalized_timestamps(risk_rows, artifact="risk_events.jsonl")
         run_failure = _load_json(root / "run_failure.json")
+        _assert_no_float_tokens(run_failure, artifact="run_failure.json")
         _validate_run_failure_payload(run_failure)
         _assert_no_forbidden_paths(run_failure, artifact="run_failure.json")
         _assert_normalized_timestamps(run_failure, artifact="run_failure.json")
-
-    pack_manifest = _load_json(root / "artifact_pack_manifest.json")
-    _assert_no_forbidden_paths(pack_manifest, artifact="artifact_pack_manifest.json")
-    _assert_normalized_timestamps(pack_manifest, artifact="artifact_pack_manifest.json")
-    pack_file_hashes = _validate_artifact_pack_manifest(
-        root,
-        pack_manifest,
-        expected_hash_scope=_pack_hash_scope_from_artifacts(expected_artifacts),
-        expected_run_status=run_status,
-    )
-    pack_root_hash = str(pack_manifest["root_hash"])
-
-    run_digests = _load_json(root / "run_digests.json")
-    _assert_no_forbidden_paths(run_digests, artifact="run_digests.json")
-    _assert_normalized_timestamps(run_digests, artifact="run_digests.json")
-    replay_identity = manifest.get("replay_identity")
-    if not isinstance(replay_identity, dict):
-        raise S2ArtifactError(
-            "SCHEMA_INVALID",
-            "manifest replay_identity invalid",
-            {"artifact": "paper_run_manifest.json"},
-        )
-    replay_digest = str(replay_identity.get("digest_sha256") or "")
-    digest_map = _validate_run_digests(
-        root,
-        run_digests,
-        pack_file_hashes=pack_file_hashes,
-        manifest_replay_digest=replay_digest,
-        pack_root_hash=pack_root_hash,
-        expected_artifacts=expected_artifacts,
-    )
 
     return {
         "run_dir": str(root),

--- a/src/s2/failure.py
+++ b/src/s2/failure.py
@@ -26,6 +26,33 @@ ALLOWED_ERROR_CODES = frozenset(
     }
 )
 
+ERROR_PRECEDENCE = (
+    "SCHEMA_INVALID",
+    "ARTIFACT_MISSING",
+    "DIGEST_MISMATCH",
+    "INPUT_DIGEST_MISMATCH",
+    "INPUT_MISSING",
+    "INPUT_INVALID",
+    "MISSING_CRITICAL_FUNDING_WINDOW",
+    "DATA_INTEGRITY_FAILURE",
+    "ORDERING_INVALID",
+    "SIMULATION_FAILED",
+)
+_ERROR_PRECEDENCE_RANK = {code: idx for idx, code in enumerate(ERROR_PRECEDENCE)}
+
+
+def resolve_error_code(candidates: Sequence[str]) -> str:
+    valid_codes: list[str] = []
+    for candidate in candidates:
+        code = str(candidate).strip().upper()
+        if code in ALLOWED_ERROR_CODES:
+            valid_codes.append(code)
+    if not valid_codes:
+        return "SIMULATION_FAILED"
+    return min(
+        valid_codes, key=lambda code: _ERROR_PRECEDENCE_RANK.get(code, len(ERROR_PRECEDENCE))
+    )
+
 
 @dataclass(frozen=True)
 class S2StructuredFailure:

--- a/tests/s2/test_artifacts_replay.py
+++ b/tests/s2/test_artifacts_replay.py
@@ -23,6 +23,7 @@ from s2.canonical import (
     canonical_json_text,
 )
 from s2.core import S2CoreConfig, S2CoreResult
+from s2.failure import resolve_error_code
 from s2.models import FeeModel, FundingModel, LiquidationModel, SlippageBucket, SlippageModel
 
 
@@ -100,6 +101,43 @@ def _funding_gap_request(data_path: Path) -> S2ArtifactRequest:
             ),
         ),
     )
+
+
+def _recompute_pack_manifest_and_run_digests(
+    *,
+    run_dir: Path,
+    request: S2ArtifactRequest,
+    artifacts: tuple[str, ...],
+    run_status: str,
+) -> None:
+    pack_manifest = artifacts_module._build_artifact_pack_manifest(
+        request.run_id,
+        run_dir,
+        artifacts=artifacts,
+        run_status=run_status,
+    )
+    artifacts_module.write_canonical_json(run_dir / "artifact_pack_manifest.json", pack_manifest)
+
+    artifact_digests = {
+        name: artifacts_module.sha256_hex_file(run_dir / name)
+        for name in sorted(artifacts)
+        if name != "run_digests.json"
+    }
+    manifest_payload = json.loads((run_dir / "paper_run_manifest.json").read_text(encoding="utf-8"))
+    replay_digest = str(manifest_payload["replay_identity"]["digest_sha256"])
+    run_digests_payload = {
+        "schema_version": artifacts_module.RUN_DIGESTS_SCHEMA,
+        "numeric_policy_id": NUMERIC_POLICY_ID,
+        "numeric_policy_digest_sha256": NUMERIC_POLICY_DIGEST_SHA256,
+        "run_id": request.run_id,
+        "artifact_sha256": artifact_digests,
+        "artifact_pack_root_hash": pack_manifest["root_hash"],
+        "artifact_pack_files_sha256": {
+            str(row["path"]): str(row["sha256"]) for row in pack_manifest["files"]
+        },
+        "replay_identity_digest_sha256": replay_digest,
+    }
+    artifacts_module.write_canonical_json(run_dir / "run_digests.json", run_digests_payload)
 
 
 def test_double_run_identical_inputs_identical_artifact_bytes_and_digests(tmp_path: Path) -> None:
@@ -193,12 +231,19 @@ def test_input_digest_validation_fail_closed(tmp_path: Path) -> None:
 def test_schema_validation_fail_closed(tmp_path: Path) -> None:
     data_path = tmp_path / "bars.csv"
     _write_sample_csv(data_path)
-    run_dir = run_s2_artifact_pack(_request(data_path), tmp_path / "out")
+    request = _request(data_path)
+    run_dir = run_s2_artifact_pack(request, tmp_path / "out")
 
     manifest_path = run_dir / "paper_run_manifest.json"
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     payload.pop("strategy", None)
     manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    _recompute_pack_manifest_and_run_digests(
+        run_dir=run_dir,
+        request=request,
+        artifacts=REQUIRED_ARTIFACTS,
+        run_status=RUN_STATUS_SUCCEEDED,
+    )
 
     with pytest.raises(S2ArtifactError, match="SCHEMA_INVALID"):
         validate_s2_artifact_pack(run_dir)
@@ -222,7 +267,8 @@ def test_digest_validation_fail_closed(tmp_path: Path) -> None:
 def test_missing_schema_version_row_fails_closed(tmp_path: Path) -> None:
     data_path = tmp_path / "bars.csv"
     _write_sample_csv(data_path)
-    run_dir = run_s2_artifact_pack(_request(data_path), tmp_path / "out")
+    request = _request(data_path)
+    run_dir = run_s2_artifact_pack(request, tmp_path / "out")
 
     path = run_dir / "decision_records.jsonl"
     rows = [
@@ -232,6 +278,12 @@ def test_missing_schema_version_row_fails_closed(tmp_path: Path) -> None:
     path.write_bytes(
         ("\n".join(json.dumps(row, separators=(",", ":")) for row in rows) + "\n").encode("utf-8")
     )
+    _recompute_pack_manifest_and_run_digests(
+        run_dir=run_dir,
+        request=request,
+        artifacts=REQUIRED_ARTIFACTS,
+        run_status=RUN_STATUS_SUCCEEDED,
+    )
 
     with pytest.raises(S2ArtifactError, match="SCHEMA_INVALID"):
         validate_s2_artifact_pack(run_dir)
@@ -240,7 +292,8 @@ def test_missing_schema_version_row_fails_closed(tmp_path: Path) -> None:
 def test_wrong_schema_version_row_fails_closed(tmp_path: Path) -> None:
     data_path = tmp_path / "bars.csv"
     _write_sample_csv(data_path)
-    run_dir = run_s2_artifact_pack(_request(data_path), tmp_path / "out")
+    request = _request(data_path)
+    run_dir = run_s2_artifact_pack(request, tmp_path / "out")
 
     path = run_dir / "simulated_fills.jsonl"
     rows = [
@@ -249,6 +302,12 @@ def test_wrong_schema_version_row_fails_closed(tmp_path: Path) -> None:
     rows[0]["schema_version"] = "s2/simulated_fills/v0"
     path.write_bytes(
         ("\n".join(json.dumps(row, separators=(",", ":")) for row in rows) + "\n").encode("utf-8")
+    )
+    _recompute_pack_manifest_and_run_digests(
+        run_dir=run_dir,
+        request=request,
+        artifacts=REQUIRED_ARTIFACTS,
+        run_status=RUN_STATUS_SUCCEEDED,
     )
 
     with pytest.raises(S2ArtifactError, match="SCHEMA_INVALID"):
@@ -394,3 +453,118 @@ def test_numeric_policy_mismatch_fails_closed(tmp_path: Path) -> None:
 
     with pytest.raises(S2ArtifactError, match="SCHEMA_INVALID"):
         validate_s2_artifact_pack(run_dir)
+
+
+def test_float_token_in_jsonl_fails_closed_even_if_digests_recomputed(tmp_path: Path) -> None:
+    data_path = tmp_path / "bars.csv"
+    _write_sample_csv(data_path)
+    request = _request(data_path)
+    run_dir = run_s2_artifact_pack(request, tmp_path / "out")
+
+    path = run_dir / "decision_records.jsonl"
+    rows = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    rows[0]["seed"] = 11.125
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n" for row in rows),
+        encoding="utf-8",
+        newline="\n",
+    )
+    _recompute_pack_manifest_and_run_digests(
+        run_dir=run_dir,
+        request=request,
+        artifacts=REQUIRED_ARTIFACTS,
+        run_status=RUN_STATUS_SUCCEEDED,
+    )
+
+    with pytest.raises(S2ArtifactError, match="float token") as excinfo:
+        validate_s2_artifact_pack(run_dir)
+    assert excinfo.value.code == "SCHEMA_INVALID"
+
+
+def test_float_token_in_run_failure_context_fails_closed_even_if_digests_recomputed(
+    tmp_path: Path,
+) -> None:
+    data_path = tmp_path / "bars.csv"
+    _write_sample_csv(data_path)
+    request = _funding_gap_request(data_path)
+
+    with pytest.raises(S2ArtifactError, match="MISSING_CRITICAL_FUNDING_WINDOW"):
+        run_s2_artifact_pack(request, tmp_path / "out")
+
+    run_dir = tmp_path / "out" / "s2fail001"
+    path = run_dir / "run_failure.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["error"]["context"]["probe_float"] = 1.2345
+    path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    _recompute_pack_manifest_and_run_digests(
+        run_dir=run_dir,
+        request=request,
+        artifacts=REQUIRED_FAILURE_ARTIFACTS,
+        run_status=RUN_STATUS_FAILED,
+    )
+
+    with pytest.raises(S2ArtifactError, match="float token") as excinfo:
+        validate_s2_artifact_pack(run_dir)
+    assert excinfo.value.code == "SCHEMA_INVALID"
+
+
+def test_resolve_error_code_precedence_contract() -> None:
+    assert (
+        resolve_error_code(["MISSING_CRITICAL_FUNDING_WINDOW", "SCHEMA_INVALID"])
+        == "SCHEMA_INVALID"
+    )
+    assert resolve_error_code(["unknown_code", "NOT_REAL", "DIGEST_MISMATCH"]) == "DIGEST_MISMATCH"
+
+
+def test_failure_precedence_integration_uses_resolver(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    data_path = tmp_path / "bars.csv"
+    _write_sample_csv(data_path)
+    request = S2ArtifactRequest(
+        run_id="s2run001",
+        symbol="BTCUSDT",
+        timeframe="1m",
+        seed=11,
+        data_path=str(data_path),
+        strategy_version="strategy.demo.v1",
+        data_sha256="0" * 64,
+        strategy_config={"actions": ["LONG", "HOLD", "FLAT", "HOLD"]},
+        risk_version="risk.demo.v1",
+        risk_config={"blocked_event_seqs": []},
+        core_config=_request(data_path).core_config,
+    )
+    captured: dict[str, tuple[str, ...]] = {}
+    real_resolver = artifacts_module.resolve_error_code
+
+    def _capture(candidates: tuple[str, ...] | list[str]) -> str:
+        captured["candidates"] = tuple(str(item) for item in candidates)
+        return real_resolver(candidates)
+
+    monkeypatch.setattr(artifacts_module, "resolve_error_code", _capture)
+
+    with pytest.raises(S2ArtifactError, match="INPUT_DIGEST_MISMATCH"):
+        run_s2_artifact_pack(request, tmp_path / "out")
+
+    failure_dir = tmp_path / "out" / "s2run001"
+    run_failure = json.loads((failure_dir / "run_failure.json").read_text(encoding="utf-8"))
+    assert run_failure["error"]["error_code"] == "DIGEST_MISMATCH"
+    assert set(captured["candidates"]) >= {"DIGEST_MISMATCH", "INPUT_DIGEST_MISMATCH"}
+
+
+def test_digest_check_precedes_json_parse(tmp_path: Path) -> None:
+    data_path = tmp_path / "bars.csv"
+    _write_sample_csv(data_path)
+    run_dir = run_s2_artifact_pack(_request(data_path), tmp_path / "out")
+
+    (run_dir / "decision_records.jsonl").write_bytes(b"{\n")
+
+    with pytest.raises(S2ArtifactError) as excinfo:
+        validate_s2_artifact_pack(run_dir)
+    assert excinfo.value.code == "DIGEST_MISMATCH"


### PR DESCRIPTION
## What changed\n\nThis runtime-only PR closes the remaining S2 audit gaps for sections 3/5/6:\n\n1. Float token contamination defense\n- Added recursive _assert_no_float_tokens fail-closed validator in src/s2/artifacts.py.\n- Applied immediately after parsing every validated artifact payload (JSON and JSONL).\n\n2. Explicit failure precedence contract\n- Added precedence table + resolver esolve_error_code in src/s2/failure.py.\n- Updated failure code selection in un_s2_artifact_pack() to use resolver deterministically.\n\n3. Digest verification before parse\n- Reordered alidate_s2_artifact_pack() so rtifact_pack_manifest.json and un_digests.json integrity checks execute before semantic parsing of other artifacts.\n- Tampered payloads now fail with DIGEST_MISMATCH before JSON/JSONL parse errors.\n\n## Tests added/updated\n- Added tests for float token rejection even after recomputed digests.\n- Added precedence unit + integration tests.\n- Added digest-before-parse regression test.\n- Updated schema-mutation tests to recompute digests when asserting semantic SCHEMA_INVALID.\n\n## Files changed\n- src/s2/failure.py\n- src/s2/artifacts.py\n- 	ests/s2/test_artifacts_replay.py\n\n## Validation run\n- python -m ruff format .\n- python -m ruff check .\n- python -m pytest -q\n- python -m tools.release_gate --strict --timeout-seconds 900\n\nAll green locally.